### PR TITLE
夜中の時間帯に、CIでテストが落ちる問題を修正

### DIFF
--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -42,7 +42,7 @@ class Record::Fetcher
     elsif @year.nonzero?
       records.the_year(Date.new(@year, 1, 1))
     else
-      records.the_day(Date.today)
+      records.the_day(Time.zone.now.to_date)
     end
   end
 end


### PR DESCRIPTION
## 対応背景

CI上でのみ夜中に落ちるテストがあることがわかりました。
## 原因と対策

`Date.today`では、設定されたTimezoneが使われません。
設定されているTimezoneを使うために、`TimeWithZone`クラスを使うように修正しました。
