### PR TITLE
CSV形式でダウンロードした場合、カテゴリ絞込みをしてもすべてのデータが出力される

### DIFF
--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -28,7 +28,9 @@ class Record::Fetcher
   end
 
   def all_as_csv
+p @category_id
     records = @user.records.order(:published_at)
+    records = records.where(category_id: @category_id) if @category_id
     find_by_date(records)
   end
 

--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -28,7 +28,6 @@ class Record::Fetcher
   end
 
   def all_as_csv
-p @category_id
     records = @user.records.order(:published_at)
     records = records.where(category_id: @category_id) if @category_id
     find_by_date(records)

--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -29,8 +29,8 @@ class Record::Fetcher
 
   def all_as_csv
     records = @user.records.order(:published_at)
-    records = records.where(category_id: @category_id) if @category_id
-    find_by_date(records)
+    records = find_by_date(records)
+    records.where(category_id: @category_id) if @category_id
   end
 
   private

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,5 +14,3 @@ test:
 production:
   <<: *default
   database: account-book-pig_production
-  user: <%= ENV['POSTGRESQL_USERNAME'] %>
-  host: db

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,3 +14,5 @@ test:
 production:
   <<: *default
   database: account-book-pig_production
+  user: <%= ENV['POSTGRESQL_USERNAME'] %>
+  host: db

--- a/src/app/records/records.controller.coffee
+++ b/src/app/records/records.controller.coffee
@@ -139,6 +139,7 @@ RecordsController = ($filter, IndexService , RecordsFactory, localStorageService
       month: vm.month
       day: vm.day
       offset: vm.offset
+      category_id: $stateParams.category_id
     RecordsFactory.getCSVRecords(params).then((res) ->
       if window.navigator.msSaveOrOpenBlob
         blob = new Blob([ decodeURIComponent(encodeURI(result.data)) ], type: 'text/csv;charset=utf-8;')


### PR DESCRIPTION
#11 のissueです。
## 事象

「リスト」でカテゴリのラベルをクリックし、カテゴリを絞り込んでも「CSV形式でダウンロード」でダウンロードしたファイルには絞り込み前のデータが出力されます
## 対応内容

CSVファイルの作成時に、category_idのパラメータを送信していないため、また検索条件にcategory_idがないために、絞り込まれずに出力されていました。
パラメータを送信し、category_idで検索するようにしました。
