### PR TITLE
「リスト」の一覧で「カテゴリ」「内訳」「お店･施設」の絞込みクリアをできるようにする

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -6,6 +6,9 @@ class RecordsController < ApplicationController
     fetcher = Record::Fetcher.new(user: current_user, params: params)
     @user = current_user
     @records = fetcher.all
+    @category_name = fetcher.category_name
+    @breakdown_name = fetcher.breakdown_name
+    @place_name = fetcher.place_name
     @total_count = fetcher.total_count
   end
 

--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -19,9 +19,7 @@ class Record::Fetcher
     records = @user.records.order(published_at: :desc, created_at: :desc)
     records = find_by_date(records)
     records = find_by_refine(records)
-    @category_name = @user.categories.find(@category_id).name if @category_id
-    @breakdown_name = @user.breakdowns.find(@breakdown_id).name if @breakdown_id
-    @place_name = @user.places.find(@place_id).name if @place_id
+    set_refine_word
     @total_count = records.count
     records = records.offset(@offset) if @offset.present?
     records.limit(Settings.records.per)
@@ -57,5 +55,15 @@ class Record::Fetcher
     records = records.where(breakdown_id: @breakdown_id) if @breakdown_id
     records = records.where(place_id: @place_id) if @place_id
     records
+  end
+
+  def set_refine_word
+    @category_name = @user.categories.find(@category_id).name if @category_id
+    if @breakdown_id
+      breakdown = @user.breakdowns.find(@breakdown_id)
+      @breakdown_name = breakdown.name
+      @category_name = breakdown.category.name
+    end
+    @place_name = @user.places.find(@place_id).name if @place_id
   end
 end

--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Record::Fetcher
   include ActiveModel::Model
-  attr_accessor :total_count
+  attr_accessor :total_count, :category_name, :breakdown_name, :place_name
 
   def initialize(user: nil, params: nil, sort_type: nil)
     @user = user
@@ -18,9 +18,10 @@ class Record::Fetcher
   def all
     records = @user.records.order(published_at: :desc, created_at: :desc)
     records = find_by_date(records)
-    records = records.where(category_id: @category_id) if @category_id
-    records = records.where(breakdown_id: @breakdown_id) if @breakdown_id
-    records = records.where(place_id: @place_id) if @place_id
+    records = find_by_refine(records)
+    @category_name = @user.categories.find(@category_id).name if @category_id
+    @breakdown_name = @user.breakdowns.find(@breakdown_id).name if @breakdown_id
+    @place_name = @user.places.find(@place_id).name if @place_id
     @total_count = records.count
     records = records.offset(@offset) if @offset.present?
     records.limit(Settings.records.per)
@@ -34,9 +35,7 @@ class Record::Fetcher
   def all_as_csv
     records = @user.records.order(:published_at)
     records = find_by_date(records)
-    records = records.where(category_id: @category_id) if @category_id
-    records = records.where(breakdown_id: @breakdown_id) if @breakdown_id
-    records.where(place_id: @place_id) if @place_id
+    find_by_refine(records)
   end
 
   private
@@ -51,5 +50,12 @@ class Record::Fetcher
     else
       records.the_day(Time.zone.now.to_date)
     end
+  end
+
+  def find_by_refine(records)
+    records = records.where(category_id: @category_id) if @category_id
+    records = records.where(breakdown_id: @breakdown_id) if @breakdown_id
+    records = records.where(place_id: @place_id) if @place_id
+    records
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -102,12 +102,10 @@ class User < ActiveRecord::Base
   end
 
   def maximum_values
-    {
-      category: Settings.user.categories.maximum_length,
+    { category: Settings.user.categories.maximum_length,
       breakdown: Settings.category.breakdowns.maximum_length,
       place: Settings.user.places.maximum_length,
-      record: Settings.user.records.maximum_length
-    }
+      record: Settings.user.records.maximum_length }
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ActiveRecord::Base
   has_many :tags
   has_many :tallies
   has_many :captures
+  has_many :breakdowns, through: :categories
 
   enum status: { inactive: 1, registered: 2 }
 

--- a/app/views/records/index.json.jbuilder
+++ b/app/views/records/index.json.jbuilder
@@ -24,3 +24,7 @@ json.total_count @total_count
 json.user do
   json.currency @user.currency
 end
+
+json.category_name @category_name
+json.breakdown_name @breakdown_name
+json.place_name @place_name

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -153,7 +153,7 @@ describe 'GET /records', autodoc: true do
           },
           category_name: nil,
           breakdown_name: nil,
-          place_name: nil 
+          place_name: nil
         }
         expect(response.body).to be_json_as(json)
       end
@@ -217,7 +217,7 @@ describe 'GET /records', autodoc: true do
           },
           category_name: nil,
           breakdown_name: nil,
-          place_name: nil 
+          place_name: nil
         }
         expect(response.body).to be_json_as(json)
       end

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -64,7 +64,10 @@ describe 'GET /records', autodoc: true do
           total_count: 2,
           user: {
             currency: user.currency
-          }
+          },
+          category_name: nil,
+          breakdown_name: nil,
+          place_name: nil
         }
         expect(response.body).to be_json_as(json)
       end
@@ -111,7 +114,10 @@ describe 'GET /records', autodoc: true do
           total_count: 2,
           user: {
             currency: user.currency
-          }
+          },
+          category_name: nil,
+          breakdown_name: nil,
+          place_name: nil
         }
         expect(response.body).to be_json_as(json)
       end
@@ -144,7 +150,10 @@ describe 'GET /records', autodoc: true do
           total_count: 1,
           user: {
             currency: user.currency
-          }
+          },
+          category_name: nil,
+          breakdown_name: nil,
+          place_name: nil 
         }
         expect(response.body).to be_json_as(json)
       end
@@ -205,7 +214,10 @@ describe 'GET /records', autodoc: true do
           total_count: 3,
           user: {
             currency: user.currency
-          }
+          },
+          category_name: nil,
+          breakdown_name: nil,
+          place_name: nil 
         }
         expect(response.body).to be_json_as(json)
       end

--- a/src/app/records/list/list.jade
+++ b/src/app/records/list/list.jade
@@ -40,6 +40,11 @@ form.form.form-inline
     span(ng-show="list.selected_list == 'year'") {{ list.year }}年
     span(translate='LABELS.ADD_RECORDS')
   .panel-body#with-background
+    p(ng-show='list.category_name || list.breakdown_name || list.place_name')
+      span {{ 'LABELS.REFINE_SEARCH' | translate }} :
+      label.label.label-warning {{ list.category_name }}
+      label.label.label-info {{ list.breakdown_name }}
+      label.label.label-primary {{ list.place_name }}
     loading-directive
     table.table(ng-show='list.records')
       tr(ng-repeat='record in list.records')

--- a/src/app/records/list/list.jade
+++ b/src/app/records/list/list.jade
@@ -44,13 +44,13 @@ form.form.form-inline
       span {{ 'LABELS.REFINE_SEARCH' | translate }} :
       label.label.label-warning(ng-show='list.category_name')
         span {{ list.category_name }}
-        span.glyphicon.glyphicon-remove#right-icon
+        span.glyphicon.glyphicon-remove#right-icon(ng-click='list.clearCategory()')
       label.label.label-info(ng-show='list.breakdown_name')
         span {{ list.breakdown_name }}
-        span.glyphicon.glyphicon-remove#right-icon
+        span.glyphicon.glyphicon-remove#right-icon(ng-click='list.clearBreakdown()')
       label.label.label-primary(ng-show='list.place_name')
         span {{ list.place_name }}
-        span.glyphicon.glyphicon-remove#right-icon
+        span.glyphicon.glyphicon-remove#right-icon(ng-click='list.clearPlace()')
     loading-directive
     table.table(ng-show='list.records')
       tr(ng-repeat='record in list.records')

--- a/src/app/records/list/list.jade
+++ b/src/app/records/list/list.jade
@@ -42,9 +42,15 @@ form.form.form-inline
   .panel-body#with-background
     p(ng-show='list.category_name || list.breakdown_name || list.place_name')
       span {{ 'LABELS.REFINE_SEARCH' | translate }} :
-      label.label.label-warning {{ list.category_name }}
-      label.label.label-info {{ list.breakdown_name }}
-      label.label.label-primary {{ list.place_name }}
+      label.label.label-warning(ng-show='list.category_name')
+        span {{ list.category_name }}
+        span.glyphicon.glyphicon-remove#right-icon
+      label.label.label-info(ng-show='list.breakdown_name')
+        span {{ list.breakdown_name }}
+        span.glyphicon.glyphicon-remove#right-icon
+      label.label.label-primary(ng-show='list.place_name')
+        span {{ list.place_name }}
+        span.glyphicon.glyphicon-remove#right-icon
     loading-directive
     table.table(ng-show='list.records')
       tr(ng-repeat='record in list.records')

--- a/src/app/records/records.controller.coffee
+++ b/src/app/records/records.controller.coffee
@@ -25,6 +25,9 @@ RecordsController = ($filter, IndexService , RecordsFactory, localStorageService
       vm.records = res.records
       vm.total_count = res.total_count
       vm.user = res.user
+      vm.category_name = res.category_name
+      vm.breakdown_name = res.breakdown_name
+      vm.place_name = res.place_name
       total_array = []
       for i in [0..vm.total_count]
         total_array.push(i)

--- a/src/app/records/records.controller.coffee
+++ b/src/app/records/records.controller.coffee
@@ -233,6 +233,72 @@ RecordsController = ($filter, IndexService , RecordsFactory, localStorageService
         place_id: place_id
       )
 
+  # カテゴリの絞込みをクリアする
+  vm.clearCategory = () ->
+    vm.category_name = undefined
+    if vm.selected_list == 'year'
+      $state.go('yearly_list',
+        year: vm.year
+        category_id: undefined
+      )
+    else if vm.selected_list == 'month'
+      $state.go('monthly_list',
+        year: vm.year
+        month: ('0' + vm.month).slice(-2)
+        category_id: undefined
+      )
+    else if vm.selected_list == 'day'
+      $state.go('daily_list',
+        year: Number($filter('date')(vm.date, 'yyyy'))
+        month: ('0' + Number($filter('date')(vm.date, 'MM'))).slice(-2)
+        day: ('0' + Number($filter('date')(vm.date, 'dd'))).slice(-2)
+        category_id: undefined
+      )
+
+  # 内訳の絞込みをクリアする
+  vm.clearBreakdown = () ->
+    vm.breakdown_name = undefined
+    if vm.selected_list == 'year'
+      $state.go('yearly_list',
+        year: vm.year
+        breakdown_id: undefined
+      )
+    else if vm.selected_list == 'month'
+      $state.go('monthly_list',
+        year: vm.year
+        month: ('0' + vm.month).slice(-2)
+        breakdown_id: undefined
+      )
+    else if vm.selected_list == 'day'
+      $state.go('daily_list',
+        year: Number($filter('date')(vm.date, 'yyyy'))
+        month: ('0' + Number($filter('date')(vm.date, 'MM'))).slice(-2)
+        day: ('0' + Number($filter('date')(vm.date, 'dd'))).slice(-2)
+        breakdown_id: undefined
+      )
+
+  # お店・施設の絞込みをクリアする
+  vm.clearPlace = () ->
+    vm.place_name = undefined
+    if vm.selected_list == 'year'
+      $state.go('yearly_list',
+        year: vm.year
+        place_id: undefined
+      )
+    else if vm.selected_list == 'month'
+      $state.go('monthly_list',
+        year: vm.year
+        month: ('0' + vm.month).slice(-2)
+        place_id: undefined
+      )
+    else if vm.selected_list == 'day'
+      $state.go('daily_list',
+        year: Number($filter('date')(vm.date, 'yyyy'))
+        month: ('0' + Number($filter('date')(vm.date, 'MM'))).slice(-2)
+        day: ('0' + Number($filter('date')(vm.date, 'dd'))).slice(-2)
+        place_id: undefined
+      )
+
   getRecordsWithDate()
 
   return

--- a/src/assets/i18n/locale-en.json
+++ b/src/assets/i18n/locale-en.json
@@ -92,6 +92,7 @@
     "TWITTER_LOGIN": "Login via Twitter",
     "EMAIL_LOGIN": "Login via Email",
     "PRE_AUTH": "Pre-authentication",
+    "REFINE_SEARCH": "Refine words",
     "SELECTED": "Selected",
     "UNREAD": "Unread"
   },

--- a/src/assets/i18n/locale-ja.json
+++ b/src/assets/i18n/locale-ja.json
@@ -93,6 +93,7 @@
     "TWITTER_LOGIN": "Twitterでログインしています",
     "EMAIL_LOGIN": "メールアドレスでログインしています",
     "PRE_AUTH": "認証前",
+    "REFINE_SEARCH": "絞込み",
     "SELECTED": "登録済",
     "UNREAD": "未読"
   },


### PR DESCRIPTION
#7 の対応です。
## 実装内容
- カテゴリのラベルクリック時、絞り込んだカテゴリ名を表示
- 内訳のラベルクリック時、絞り込んだ内訳の名称を表示
- お店・施設のラベルクリック時、絞り込んだお店・施設の名称を表示
- 表示したカテゴリ名、内訳、お店・施設名をクリアするリンクを配置
- クリアした場合、クリア後の条件で再検索
## 実装理由

ラベルクリック時に絞り込んで検索しますが、絞り込んだキーワードが何かを明示的に表示することで、検索条件をわかりするため
絞り込んだ条件をクリアするボタンを配置するため
