### PR TITLE
内訳を絞り込んだ際もカテゴリラベルを表示しない

### DIFF
--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -59,11 +59,7 @@ class Record::Fetcher
 
   def set_refine_word
     @category_name = @user.categories.find(@category_id).name if @category_id
-    if @breakdown_id
-      breakdown = @user.breakdowns.find(@breakdown_id)
-      @breakdown_name = breakdown.name
-      @category_name = breakdown.category.name
-    end
+    @breakdown_name = @user.breakdowns.find(@breakdown_id).name if @breakdown_id
     @place_name = @user.places.find(@place_id).name if @place_id
   end
 end


### PR DESCRIPTION
# 対応理由

内訳を選択＝カテゴリと内訳を選択
という理屈上での正しさはあるものの、操作において既にカテゴリを選択しているのか、内訳のみを選択しているのかを見分けるのが難しいため
# 対応内容

「リスト」の一覧のカテゴリラベルを選択していない場合、絞込みにカテゴリ名を表示しないようにしました。
