### PR TITLE
メールアドレス認証部分のリファクタリング

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,12 +46,12 @@ class UsersController < ApplicationController
 
   # GET /user/authorize_email
   def authorize_email
-    user = User.find(params[:user_id])
-    if user.update_email_by(params[:token])
+    updator = User::EmailUpdator.new(email_params)
+    if updator.authorize
       host = Rails.env.production? ? '' : 'http://localhost:3000'
       redirect_to "#{host}/#/?updated_email=ok"
     else
-      render_error user, 401
+      render_error updator.user, 401
     end
   end
 
@@ -81,5 +81,9 @@ class UsersController < ApplicationController
   def setting_params
     params.permit(:breakdown_field, :place_field, :tag_field, :memo_field,
                   :currency)
+  end
+
+  def email_params
+    params.permit(:user_id, :token)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,14 +86,8 @@ class User < ActiveRecord::Base
     @new_email_token ||= add_new_email_token
   end
 
-  def update_email_by(token)
-    token_user = User.find_by_valid_token(:new_email, token)
-    if self == token_user
-      update(email: new_email, new_email: '') && remove_token(:new_email)
-    else
-      errors[:base] << I18n.t('errors.messages.users.invalid_token')
-      false
-    end
+  def authorize_new_email
+    update(email: new_email, new_email: '')
   end
 
   def each_maximum_values

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -102,8 +102,6 @@ class User < ActiveRecord::Base
       record: Settings.user.records.maximum_length }
   end
 
-  private
-
   def add_new_email_token
     add_token(
       :new_email,
@@ -111,6 +109,8 @@ class User < ActiveRecord::Base
       expires_at: Settings.new_email_token.expire_after.seconds.from_now
     )
   end
+
+  private
 
   def set_currency
     self.currency = '¥' # TODO: ロケールによりデフォルトを変更する

--- a/app/models/user/email_updator.rb
+++ b/app/models/user/email_updator.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+class User::EmailUpdator
+  attr_accessor :user
+
+  def initialize(params)
+    @user = User.find(params[:user_id])
+    @token = params[:token]
+  end
+
+  def authorize
+    token_user = User.find_by_valid_token(:new_email, @token)
+    if token_user == @user
+      @user.authorize_new_email && @user.remove_token(:new_email)
+    else
+      @user.errors[:base] << I18n.t('errors.messages.users.invalid_token')
+      false
+    end
+  end
+end

--- a/spec/models/user/email_updator_spec.rb
+++ b/spec/models/user/email_updator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe User::EmailUpdator, type: :model do

--- a/spec/models/user/email_updator_spec.rb
+++ b/spec/models/user/email_updator_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe User::EmailUpdator, type: :model do
+  let!(:user) { create(:email_user, :registered, new_email: new_email) }
+  let!(:updator) { User::EmailUpdator.new(email_params) }
+  let!(:email_params) { { user_id: user.id, token: token } }
+  let!(:token) { user.add_new_email_token.token }
+  let(:new_email) { 'new_email@example.com' }
+
+  it 'has user' do
+    expect(updator.user).to eq user
+  end
+
+  describe '#authorize' do
+    context 'token is valid' do
+      it 'updated new email' do
+        expect(user.new_email).to eq new_email
+        updator.authorize
+        user.reload
+        expect(user.email).to eq new_email
+        expect(user.new_email).to eq ''
+      end
+    end
+
+    context 'token is invalid' do
+      let(:token) { 'invalid_token' }
+
+      it 'dont update new email' do
+        expect(user.new_email).to eq new_email
+        updator.authorize
+        user.reload
+        expect(user.new_email).to eq new_email
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,4 +14,27 @@ RSpec.describe User, type: :model do
   describe 'バリデーション' do
     it { is_expected.to validate_length_of(:nickname).is_at_most(100) }
   end
+
+  shared_examples_for '#authorize_new_email' do
+    let(:new_email) { 'new_email@example.com' }
+
+    it 'update email' do
+      expect(user.new_email).to eq new_email
+      user.authorize_new_email
+      expect(user.email).to eq new_email
+      expect(user.new_email).to eq ''
+    end
+  end
+
+  context 'email user' do
+    let!(:user) { create(:email_user, :registered, new_email: new_email) }
+
+    it_behaves_like '#authorize_new_email'
+  end
+
+  context 'twitter user' do
+    let!(:user) { create(:twitter_user, :registered, new_email: new_email) }
+
+    it_behaves_like '#authorize_new_email'
+  end
 end


### PR DESCRIPTION
## 対応理由

`models/user.rb`が100行を越えようとしており、
`update_email_by(token)`メソッドでリファクタリングできそうだったので対応
## 対応内容
- メールアドレス認証の完了（つまり、対象ユーザーの`new_email`から`email`にメールアドレスを移動・登録）を行う一連の処理を`EmailUpdator`に切り出し、更新メソッド`authorize_new_email`のみに変更しました
- `#authorize_new_email`のテストを追加しました
## 補足

対応中に発見したバグがありました。別件で対応します。issue #20 
