### PR TITLE
カテゴリ、お店・施設、記録の作成上限数を設定

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -8,11 +8,11 @@ class CategoriesController < ApplicationController
   end
 
   def create
-    current_user.categories.new(new_category_params)
-    if current_user.save
+    category = current_user.categories.new(new_category_params)
+    if category.save
       head 201
     else
-      render_error current_user
+      render_error category
     end
   end
 

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -10,11 +10,11 @@ class PlacesController < ApplicationController
   end
 
   def create
-    current_user.places.new(place_params)
-    if current_user.save
+    place = current_user.places.new(place_params)
+    if place.save
       head 201
     else
-      render_error current_user
+      render_error place
     end
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -13,6 +13,7 @@ class Category < ActiveRecord::Base
   validates :breakdowns,
             length: { maximum: Settings.category.breakdowns.maximum_length,
                       too_long: I18n.t('errors.messages.too_many') }
+  validate :should_be_less_than_maximum, on: :create
 
   before_create :set_position
   before_destroy :confirm_contents
@@ -41,6 +42,19 @@ class Category < ActiveRecord::Base
       I18n.t('labels.barance_of_payments.income')
     else
       I18n.t('labels.barance_of_payments.outgo')
+    end
+  end
+
+  private
+
+  def should_be_less_than_maximum
+    maximum_count = if user.admin
+                      Settings.user.categories.admin_maximum_length
+                    else
+                      Settings.user.categories.maximum_length
+                    end
+    if maximum_count <= user.categories.count
+      errors[:base] << I18n.t('errors.messages.categories.too_many', count: maximum_count)
     end
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -54,7 +54,8 @@ class Category < ActiveRecord::Base
                       Settings.user.categories.maximum_length
                     end
     if maximum_count <= user.categories.count
-      errors[:base] << I18n.t('errors.messages.categories.too_many', count: maximum_count)
+      errors[:base] <<
+        I18n.t('errors.messages.categories.too_many', count: maximum_count)
     end
   end
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -9,8 +9,22 @@ class Place < ActiveRecord::Base
   validates :name,
             presence: true,
             length: { maximum: Settings.place.name.maximum_length }
+  validate :should_be_less_than_maximum, on: :create
 
   def categorize?(category_id)
     categories.map(&:id).include?(category_id)
+  end
+
+  private
+
+  def should_be_less_than_maximum
+    maximum_count = if user.admin
+                      Settings.user.places.admin_maximum_length
+                    else
+                      Settings.user.places.maximum_length
+                    end
+    if maximum_count <= user.places.count
+      errors[:base] << I18n.t('errors.messages.places.too_many', count: maximum_count)
+    end
   end
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -24,7 +24,8 @@ class Place < ActiveRecord::Base
                       Settings.user.places.maximum_length
                     end
     if maximum_count <= user.places.count
-      errors[:base] << I18n.t('errors.messages.places.too_many', count: maximum_count)
+      errors[:base] <<
+        I18n.t('errors.messages.places.too_many', count: maximum_count)
     end
   end
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -71,7 +71,8 @@ class Record < ActiveRecord::Base
                       Settings.user.records.maximum_length
                     end
     if maximum_count <= user.records.count
-      errors[:base] << I18n.t('errors.messages.records.too_many', count: maximum_count)
+      errors[:base] <<
+        I18n.t('errors.messages.records.too_many', count: maximum_count)
     end
   end
 end

--- a/config/application.yml
+++ b/config/application.yml
@@ -47,7 +47,7 @@ defaults: &defaults
       admin_maximum_length: 99
     records:
       maximum_length: 200
-      admin_maximum_length: 999
+      admin_maximum_length: 9999
     nickname:
       maximum_length: 100
     email:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,9 +10,14 @@ ja:
         failed_to_sort: 並び替えに失敗しました。
         destroy_breakdowns: 登録した内訳を削除してから削除してください
         destroy_records: 登録した収支を削除してから削除してください
-      too_many: の作成上限は%{count}件です
+        too_many: カテゴリの作成上限は%{count}件です
+      places:
+        too_many: お店・施設の作成上限は%{count}件です
+      records:
+        too_many: 登録上限は%{count}件です
       registrations:
         not_found_email: メールアドレスがすでに本登録されているか、登録されていないメールアドレスです
+      too_many: の作成上限は%{count}件です
   labels:
     administrator: 管理者
     status:

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -2,12 +2,15 @@
 require 'rails_helper'
 
 RSpec.describe Category, type: :model do
-  it { is_expected.to belong_to(:user) }
-  it { is_expected.to have_many(:breakdowns) }
-  it { is_expected.to have_many(:categorize_places) }
-  it { is_expected.to have_many(:places).through(:categorize_places) }
-  it { is_expected.to have_many(:records) }
-  it { is_expected.to have_many(:captures) }
-  it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_length_of(:name).is_at_most(100) }
+  describe 'validation' do
+    subject { create(:category, user: create(:email_user, :registered)) }
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_many(:breakdowns) }
+    it { is_expected.to have_many(:categorize_places) }
+    it { is_expected.to have_many(:places).through(:categorize_places) }
+    it { is_expected.to have_many(:records) }
+    it { is_expected.to have_many(:captures) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_most(100) }
+  end
 end

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -2,11 +2,14 @@
 require 'rails_helper'
 
 RSpec.describe Place, type: :model do
-  it { is_expected.to belong_to(:user) }
-  it { is_expected.to have_many(:categorize_places) }
-  it { is_expected.to have_many(:categories).through(:categorize_places) }
-  it { is_expected.to have_many(:records) }
-  it { is_expected.to have_many(:captures) }
-  it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_length_of(:name).is_at_most(100) }
+  describe 'validation' do
+    subject { create(:place, user: create(:email_user, :registered)) }
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_many(:categorize_places) }
+    it { is_expected.to have_many(:categories).through(:categorize_places) }
+    it { is_expected.to have_many(:records) }
+    it { is_expected.to have_many(:captures) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_most(100) }
+  end
 end

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -6,12 +6,14 @@ RSpec.describe Record, type: :model do
   it { is_expected.to belong_to(:category) }
   it { is_expected.to belong_to(:breakdown) }
   it { is_expected.to belong_to(:place) }
-
-  it { is_expected.to validate_presence_of(:published_at) }
-  it { is_expected.to validate_presence_of(:charge) }
-  it { is_expected.to validate_presence_of(:category) }
-
   it { is_expected.to have_many(:tagged_records) }
   it { is_expected.to have_many(:tags).through(:tagged_records) }
-  it { is_expected.to validate_length_of(:memo).is_at_most(10_000) }
+
+  describe 'validation' do
+    subject { create(:record, user: create(:email_user, :registered)) }
+    it { is_expected.to validate_presence_of(:published_at) }
+    it { is_expected.to validate_presence_of(:charge) }
+    it { is_expected.to validate_presence_of(:category) }
+    it { is_expected.to validate_length_of(:memo).is_at_most(10_000) }
+  end
 end

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -94,7 +94,7 @@ describe 'POST /categories', autodoc: true do
       expect(response.status).to eq 422
 
       json = {
-        error_messages: ['カテゴリは不正な値です']
+        error_messages: ['カテゴリ名を入力してください']
       }
       expect(response.body).to be_json_as(json)
     end
@@ -224,15 +224,16 @@ describe 'POST /categories/sort', autodoc: true do
 
   context 'メールアドレスのユーザーがログインしている場合' do
     let!(:user) { create(:email_user, :registered) }
-    let!(:category1) { create(:category, user: user) }
-    let!(:category2) { create(:category, user: user) }
-    let!(:category3) { create(:category, user: user) }
-    let!(:category4) { create(:category, user: user) }
-    let!(:params) do
+    let(:category1) { create(:category, user: user) }
+    let(:category2) { create(:category, user: user) }
+    let(:category3) { create(:category, user: user) }
+    let(:category4) { create(:category, user: user) }
+    let(:params) do
       { sequence: [category3.id, category2.id, category4.id, category1.id] }
     end
 
     it '200を返し、データが正しいこと' do
+      allow(Settings.user.categories).to receive(:maximum_length).and_return(5)
       post '/categories/sort', params: params, headers: login_headers(user)
       expect(response.status).to eq 200
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -2,6 +2,10 @@
 require 'rails_helper'
 
 describe 'GET /dashboard', autodoc: true do
+  before do
+    allow(Settings.user.records).to receive(:maximum_length).and_return(5)
+  end
+
   let!(:user) { create(:email_user, :registered) }
 
   context 'ログインしていない場合' do

--- a/spec/requests/place/categories_spec.rb
+++ b/spec/requests/place/categories_spec.rb
@@ -2,6 +2,9 @@
 require 'rails_helper'
 
 describe 'GET /places/:place_id/categories', autodoc: true do
+  before do
+    allow(Settings.user.categories).to receive(:maximum_length).and_return(5)
+  end
   let!(:user) { create(:email_user, :registered) }
   let!(:place) { create(:place, user: user) }
 

--- a/spec/requests/places_spec.rb
+++ b/spec/requests/places_spec.rb
@@ -76,7 +76,7 @@ describe 'POST /places?name=name', autodoc: true do
         post '/places', params: params, headers: login_headers(user)
         expect(response.status).to eq 422
         json = {
-          error_messages: ['お店・施設は不正な値です']
+          error_messages: ['お店・施設名を入力してください']
         }
         expect(response.body).to be_json_as(json)
       end

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -25,7 +25,7 @@
           span {{ 'COLUMNS.MEMO' | translate }}
       hr(ng-show='new_record.settings')
       .alert.alert-danger(role='alert' ng-show='new_record.total_record_count >= new_record.user.max_record_count')
-        span {{ 'MESSAGES.MAX_LENGTH_RECORDS' | translate:{ count:new_record.total_record_count } }}
+        span {{ 'MESSAGES.MAX_LENGTH_RECORDS' | translate:{ count:new_record.user.max_record_count } }}
       // フォーム
       form.form-horizontal(novalidate=true name='newRecordForm' ng-submit='new_record.submit()')
         // 日付


### PR DESCRIPTION
# 対応理由

サーバー側でバリデーションが設定されていなかったため
# 対応内容
- カテゴリ、お店・施設の422のエラーメッセージを変更しました
- カテゴリ、お店・施設、記録の作成時のみ、上限数を判別するバリデーションを設定しました
- `models/user.rb`のメソッドの順番を変更しました
- `models/user.rb`にあったvalidationをそれぞれのクラス(`category.rb`, `place.rb`, `record.rb`）に振り分けました
- 管理者の記録作成上減数を999から9999に変更しました
- 記録数が上限に達した際に表示されていたエラーメッセージが不正だったので、正しい上限数を表示するようにしました
