### PR TITLE
すでにカテゴリに紐づくデータがある場合、カテゴリを削除できないテストを追加

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -16,13 +16,16 @@ class Category < ActiveRecord::Base
   validate :should_be_less_than_maximum, on: :create
 
   before_create :set_position
-  before_destroy :confirm_contents
+  before_destroy :should_not_have_contents
 
+  # callback: before_create
   def set_position
     self.position = user.categories.count
+    # FIXME: 削除すると並び順が変わる可能性がある
   end
 
-  def confirm_contents
+  # callback: before_destroy
+  def should_not_have_contents
     if breakdowns.any?
       errors[:base] << I18n.t('errors.messages.categories.destroy_breakdowns')
       throw :abort
@@ -47,6 +50,7 @@ class Category < ActiveRecord::Base
 
   private
 
+  # validate
   def should_be_less_than_maximum
     maximum_count = if user.admin
                       Settings.user.categories.admin_maximum_length

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -2,15 +2,37 @@
 require 'rails_helper'
 
 RSpec.describe Category, type: :model do
+  let!(:category) { create(:category, user: create(:email_user, :registered)) }
+
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to have_many(:breakdowns) }
+  it { is_expected.to have_many(:categorize_places) }
+  it { is_expected.to have_many(:places).through(:categorize_places) }
+  it { is_expected.to have_many(:records) }
+  it { is_expected.to have_many(:captures) }
+
   describe 'validation' do
-    subject { create(:category, user: create(:email_user, :registered)) }
-    it { is_expected.to belong_to(:user) }
-    it { is_expected.to have_many(:breakdowns) }
-    it { is_expected.to have_many(:categorize_places) }
-    it { is_expected.to have_many(:places).through(:categorize_places) }
-    it { is_expected.to have_many(:records) }
-    it { is_expected.to have_many(:captures) }
+    subject { category }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_length_of(:name).is_at_most(100) }
+  end
+
+  describe '#should_not_have_contents' do
+    context 'have records' do
+      let!(:record) { create(:record, category: category) }
+
+      it 'occures an error' do
+        category.destroy
+        expect(category.destroyed?).to be_falsey
+        expect(category.errors.full_messages).to eq ['登録した収支を削除してから削除してください']
+      end
+    end
+
+    context 'have no record' do
+      it 'destroyed' do
+        category.destroy
+        expect(category.destroyed?).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
- カテゴリの削除前に、登録されている`record`がないかを確認するメソッドの名前を`should_not_have_contents`に変更しました
- 対象のメソッドのテストを追加しました
