### PR TITLE
「入力する」画面に表示される日付ごとのリストが今日しか表示されない問題を修正

### DIFF
--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -1,4 +1,4 @@
-NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $uibModal, SettingsFactory) ->
+NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $uibModal, SettingsFactory, $filter) ->
   'ngInject'
   vm = this
 
@@ -27,7 +27,9 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $uibModal, 
   getRecordsWithDate = (target_date) ->
     IndexService.records_loading = true
     params =
-      date: String(target_date)
+      year: Number($filter('date')(target_date, 'yyyy'))
+      month: Number($filter('date')(target_date, 'MM'))
+      day: Number($filter('date')(target_date, 'dd'))
     RecordsFactory.getRecords(params).then((res) ->
       vm.records_published_at = target_date
       vm.day_records = res.records


### PR DESCRIPTION
## 原因

「リスト」の表示のURLを変更したことにより、パラメータ名を変更したが、
「入力する」に表示されるリストのパラメータは新しいパラメータ名ではなかったため
## 対応内容

正しいパラメータ名で日付を渡すように設定
