### PR TITLE
インポート履歴で更新すると収支が表示されなくなる問題を修正

### DIFF
--- a/app/views/captures/show.json.jbuilder
+++ b/app/views/captures/show.json.jbuilder
@@ -2,6 +2,7 @@ json.id @capture.id
 json.created_at I18n.l(@capture.created_at)
 json.published_at @capture.published_at
 json.category_name @capture.category_name
+json.category_payments @capture.category.try(:barance_of_payments)
 json.category_id @capture.category_id
 json.breakdown_name @capture.breakdown_name
 json.breakdown_id @capture.breakdown_id

--- a/spec/requests/captures_spec.rb
+++ b/spec/requests/captures_spec.rb
@@ -169,6 +169,7 @@ describe 'GET /capture/:id', autodoc: true do
         created_at: capture.created_at.strftime('%Y/%m/%d %H:%M:%S'),
         published_at: capture.published_at.strftime('%Y-%m-%d'),
         category_name: capture.category_name,
+        category_payments: capture.category.try(:barance_of_payments),
         category_id: capture.category_id,
         breakdown_name: capture.breakdown_name,
         breakdown_id: capture.breakdown_id,

--- a/src/app/records/list/records.controller.coffee
+++ b/src/app/records/list/records.controller.coffee
@@ -83,7 +83,6 @@ RecordsController = ($filter, IndexService , RecordsFactory, localStorageService
   vm.selectYear = (year) ->
     vm.year = year
     vm.offset = 0
-    console.log vm.year
     $state.go('yearly_list',
       year: vm.year
       category_id: undefined


### PR DESCRIPTION
## 事象
- インポート履歴で、各データの更新をすると収支の矢印が非表示になりました
- インポート履歴で、各データのモーダルを開くとデータが更新されるので収支の矢印が非表示になりました
## 原因

データの更新時に収支の情報がレスポンス情報になかったために、収支両方でもなくなったことで非表示に成っていました
## 対応

データの更新時のレスポンスにカテゴリの収支を渡すようにしました
