### PR TITLE
管理画面のフィードバック一覧にメールアドレスを表示する

### DIFF
--- a/app/views/admin/feedbacks/index.json.jbuilder
+++ b/app/views/admin/feedbacks/index.json.jbuilder
@@ -1,13 +1,16 @@
 json.feedbacks do
   json.array! @feedbacks do |feedback|
-    user = feedback.user.decorate if feedback.user
     json.id feedback.id
     json.checked feedback.checked
     json.email feedback.email
-    json.user_id user.try(:id)
-    json.user_name user.try(:screen_name)
     json.content simple_format(feedback.content)
     json.created_at I18n.l(feedback.created_at)
+    json.user do
+      user = feedback.user.decorate if feedback.user
+      json.id user.try(:id)
+      json.screen_name user.try(:screen_name)
+      json.email user.try(:email)
+    end
   end
 end
 

--- a/spec/requests/admin/feedbacks_spec.rb
+++ b/spec/requests/admin/feedbacks_spec.rb
@@ -39,19 +39,25 @@ describe 'GET /admin/feedbacks?offset=offset', autodoc: true do
               id: user_feedback.id,
               checked: user_feedback.checked,
               email: user_feedback.email,
-              user_id: user_feedback.user_id,
-              user_name: user.try(:screen_name),
               content: simple_format(user_feedback.content),
-              created_at: I18n.l(user_feedback.created_at)
+              created_at: I18n.l(user_feedback.created_at),
+              user: {
+                id: user.try(:id),
+                screen_name: user.try(:screen_name),
+                email: user.try(:email)
+              }
             },
             {
               id: feedback.id,
               checked: feedback.checked,
               email: feedback.email,
-              user_id: feedback.user_id,
-              user_name: feedback.user.try(:screen_name),
               content: simple_format(feedback.content),
-              created_at: I18n.l(feedback.created_at)
+              created_at: I18n.l(feedback.created_at),
+              user: {
+                id: nil,
+                screen_name: nil,
+                email: nil
+              }
             }
           ],
           total_count: 2
@@ -72,10 +78,13 @@ describe 'GET /admin/feedbacks?offset=offset', autodoc: true do
               id: feedback.id,
               checked: feedback.checked,
               email: feedback.email,
-              user_id: feedback.user_id,
-              user_name: feedback.user.try(:screen_name),
               content: simple_format(feedback.content),
-              created_at: I18n.l(feedback.created_at)
+              created_at: I18n.l(feedback.created_at),
+              user: {
+                id: nil,
+                screen_name: nil,
+                email: nil
+              }
             }
           ],
           total_count: 2

--- a/src/app/admin/feedbacks/feedbacks.jade
+++ b/src/app/admin/feedbacks/feedbacks.jade
@@ -25,10 +25,12 @@ admin-menu-directive
           button.btn.btn-default(type='button' ng-click='admin_feedbacks.check($index)' ng-show='feedback.checked')
             span.glyphicon.glyphicon-ok.green#left-icon
             span(translate='BUTTONS.FINISHED')
-        td {{ feedback.email }}
+        td {{ feedback.email || feedback.user.email }}
         td
-          a(ng-click='admin_feedbacks.user(feedback.user_id)' href='')
-            span.red.glyphicon.glyphicon-user(ng-show='feedback.user_id') {{ feedback.user_name }}
+          a(href='' ng-click='admin_feedbacks.user(feedback.user.id)' ng-show='feedback.user.id')
+            span.red.glyphicon.glyphicon-user#left-icon
+            span.red {{ feedback.user.screen_name }}
+          span(ng-show='!feedback.user.id') -
         td(ng-bind-html='feedback.content')
         td {{ feedback.created_at }}
 


### PR DESCRIPTION
## 実施内容

管理画面のフィードバック一覧
- 「メールアドレス」にfeedbackに紐づくメールアドレスだけでなく、登録済みのユーザーに登録されたメールアドレスも表示するようにしました
- 「ユーザー」のアイコンとユーザー名の間に幅を追加しました
