### PR TITLE
application.ymlを整理

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -2,7 +2,7 @@
 class AdminUser < User
   def maximum_values
     {
-      category: Settings.category.maximum_admin_size,
+      category: Settings.category.max_count_of_admin,
       breakdown: Settings.category.breakdowns.admin_maximum_length,
       place: Settings.user.places.admin_maximum_length,
       record: Settings.user.records.admin_maximum_length

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -2,7 +2,7 @@
 class AdminUser < User
   def maximum_values
     {
-      category: Settings.user.categories.admin_maximum_length,
+      category: Settings.category.maximum_admin_size,
       breakdown: Settings.category.breakdowns.admin_maximum_length,
       place: Settings.user.places.admin_maximum_length,
       record: Settings.user.records.admin_maximum_length

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -4,7 +4,7 @@ class AdminUser < User
     {
       category: Settings.category.max_count_of_admin,
       breakdown: Settings.category.breakdowns.admin_maximum_length,
-      place: Settings.user.places.admin_maximum_length,
+      place: Settings.place.max_count_of_admin,
       record: Settings.user.records.admin_maximum_length
     }
   end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -5,7 +5,7 @@ class AdminUser < User
       category: Settings.category.max_count_of_admin,
       breakdown: Settings.category.breakdowns.admin_maximum_length,
       place: Settings.place.max_count_of_admin,
-      record: Settings.user.records.admin_maximum_length
+      record: Settings.record.max_count_of_admin
     }
   end
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -3,7 +3,7 @@ class AdminUser < User
   def maximum_values
     {
       category: Settings.category.max_count_of_admin,
-      breakdown: Settings.category.breakdowns.admin_maximum_length,
+      breakdown: Settings.breakdown.max_count,
       place: Settings.place.max_count_of_admin,
       record: Settings.record.max_count_of_admin
     }

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -11,7 +11,7 @@ class Category < ActiveRecord::Base
             presence: true,
             length: { maximum: Settings.category.name.maximum_length }
   validates :breakdowns,
-            length: { maximum: Settings.category.breakdowns.maximum_length,
+            length: { maximum: Settings.breakdown.max_count,
                       too_long: I18n.t('errors.messages.too_many') }
   validate :should_be_less_than_maximum, on: :create
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -53,9 +53,9 @@ class Category < ActiveRecord::Base
   # validate
   def should_be_less_than_maximum
     maximum_count = if user.admin
-                      Settings.user.categories.admin_maximum_length
+                      Settings.category.maximum_admin_size
                     else
-                      Settings.user.categories.maximum_length
+                      Settings.category.maximum_size
                     end
     if maximum_count <= user.categories.count
       errors[:base] <<

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -53,9 +53,9 @@ class Category < ActiveRecord::Base
   # validate
   def should_be_less_than_maximum
     maximum_count = if user.admin
-                      Settings.category.maximum_admin_size
+                      Settings.category.max_count_of_admin
                     else
-                      Settings.category.maximum_size
+                      Settings.category.max_count
                     end
     if maximum_count <= user.categories.count
       errors[:base] <<

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -19,9 +19,9 @@ class Place < ActiveRecord::Base
 
   def should_be_less_than_maximum
     maximum_count = if user.admin
-                      Settings.user.places.admin_maximum_length
+                      Settings.place.max_count_of_admin
                     else
-                      Settings.user.places.maximum_length
+                      Settings.place.max_count
                     end
     if maximum_count <= user.places.count
       errors[:base] <<

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -66,9 +66,9 @@ class Record < ActiveRecord::Base
 
   def should_be_less_than_maximum
     maximum_count = if user.admin
-                      Settings.record.max_count
-                    else
                       Settings.record.max_count_of_admin
+                    else
+                      Settings.record.max_count
                     end
     if maximum_count <= user.records.count
       errors[:base] <<

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -66,9 +66,9 @@ class Record < ActiveRecord::Base
 
   def should_be_less_than_maximum
     maximum_count = if user.admin
-                      Settings.user.records.admin_maximum_length
+                      Settings.record.max_count
                     else
-                      Settings.user.records.maximum_length
+                      Settings.record.max_count_of_admin
                     end
     if maximum_count <= user.records.count
       errors[:base] <<

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ActiveRecord::Base
   end
 
   def maximum_values
-    { category: Settings.category.maximum_size,
+    { category: Settings.category.max_count,
       breakdown: Settings.category.breakdowns.maximum_length,
       place: Settings.user.places.maximum_length,
       record: Settings.user.records.maximum_length }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ActiveRecord::Base
     { category: Settings.category.max_count,
       breakdown: Settings.category.breakdowns.maximum_length,
       place: Settings.place.max_count,
-      record: Settings.user.records.maximum_length }
+      record: Settings.record.max_count }
   end
 
   def add_access_token

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ActiveRecord::Base
   end
 
   def maximum_values
-    { category: Settings.user.categories.maximum_length,
+    { category: Settings.category.maximum_size,
       breakdown: Settings.category.breakdowns.maximum_length,
       place: Settings.user.places.maximum_length,
       record: Settings.user.records.maximum_length }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ActiveRecord::Base
 
   def maximum_values
     { category: Settings.category.max_count,
-      breakdown: Settings.category.breakdowns.maximum_length,
+      breakdown: Settings.breakdown.max_count,
       place: Settings.place.max_count,
       record: Settings.record.max_count }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ActiveRecord::Base
   def maximum_values
     { category: Settings.category.max_count,
       breakdown: Settings.category.breakdowns.maximum_length,
-      place: Settings.user.places.maximum_length,
+      place: Settings.place.max_count,
       record: Settings.user.records.maximum_length }
   end
 

--- a/config/application.yml
+++ b/config/application.yml
@@ -34,6 +34,8 @@ defaults: &defaults
     name:
       maximum_length: 100
   record:
+    max_count: 200
+    max_count_of_admin: 9999
     memo:
       maximum_length: 10000
   capture:
@@ -43,9 +45,6 @@ defaults: &defaults
     name:
       maximum_length: 20
   user:
-    records:
-      maximum_length: 200
-      admin_maximum_length: 9999
     nickname:
       maximum_length: 100
     email:
@@ -95,10 +94,12 @@ test:
     max_count_of_admin: 5
     name:
       maximum_length: 100
+  record:
+    max_count: 3
+    max_count_of_admin: 5
+    memo:
+      maximum_length: 10000
   user:
-    records:
-      admin_maximum_length: 5
-      maximum_length: 3
     nickname:
       maximum_length: 100
     email:

--- a/config/application.yml
+++ b/config/application.yml
@@ -29,6 +29,8 @@ defaults: &defaults
     name:
       maximum_length: 100
   place:
+    max_count: 20
+    max_count_of_admin: 99
     name:
       maximum_length: 100
   record:
@@ -41,9 +43,6 @@ defaults: &defaults
     name:
       maximum_length: 20
   user:
-    places:
-      maximum_length: 20
-      admin_maximum_length: 99
     records:
       maximum_length: 200
       admin_maximum_length: 9999
@@ -91,10 +90,12 @@ test:
       maximum_length: 3
     name:
       maximum_length: 100
+  place:
+    max_count: 3
+    max_count_of_admin: 5
+    name:
+      maximum_length: 100
   user:
-    places:
-      admin_maximum_length: 5
-      maximum_length: 3
     records:
       admin_maximum_length: 5
       maximum_length: 3

--- a/config/application.yml
+++ b/config/application.yml
@@ -21,6 +21,8 @@ defaults: &defaults
     name:
       maximum_length: 100
   category:
+    maximum_size: 20
+    maximum_admin_size: 99
     breakdowns:
       maximum_length: 20
       admin_maximum_length: 99
@@ -39,9 +41,6 @@ defaults: &defaults
     name:
       maximum_length: 20
   user:
-    categories:
-      maximum_length: 20
-      admin_maximum_length: 99
     places:
       maximum_length: 20
       admin_maximum_length: 99
@@ -85,15 +84,14 @@ development:
 test:
   <<: *defaults
   category:
+    maximum_size: 3
+    maximum_admin_size: 5
     breakdowns:
       admin_maximum_length: 5
       maximum_length: 3
     name:
       maximum_length: 100
   user:
-    categories:
-      admin_maximum_length: 5
-      maximum_length: 3
     places:
       admin_maximum_length: 5
       maximum_length: 3

--- a/config/application.yml
+++ b/config/application.yml
@@ -18,14 +18,12 @@ defaults: &defaults
   tally:
     interval: <%= 5.hours.to_i %>
   breakdown:
+    max_count: 20
     name:
       maximum_length: 100
   category:
     max_count: 20
     max_count_of_admin: 99
-    breakdowns:
-      maximum_length: 20
-      admin_maximum_length: 99
     name:
       maximum_length: 100
   place:
@@ -84,9 +82,10 @@ test:
   category:
     max_count: 3
     max_count_of_admin: 5
-    breakdowns:
-      admin_maximum_length: 5
-      maximum_length: 3
+    name:
+      maximum_length: 100
+  breakdown:
+    max_count: 3
     name:
       maximum_length: 100
   place:

--- a/config/application.yml
+++ b/config/application.yml
@@ -21,8 +21,8 @@ defaults: &defaults
     name:
       maximum_length: 100
   category:
-    maximum_size: 20
-    maximum_admin_size: 99
+    max_count: 20
+    max_count_of_admin: 99
     breakdowns:
       maximum_length: 20
       admin_maximum_length: 99
@@ -84,8 +84,8 @@ development:
 test:
   <<: *defaults
   category:
-    maximum_size: 3
-    maximum_admin_size: 5
+    max_count: 3
+    max_count_of_admin: 5
     breakdowns:
       admin_maximum_length: 5
       maximum_length: 3

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -41,7 +41,7 @@ describe 'GET /categories', autodoc: true do
             records_count: 0
           }
         ],
-        max_category_count: Settings.user.categories.maximum_length
+        max_category_count: Settings.category.maximum_size
       }
       expect(response.body).to be_json_as(json)
     end
@@ -233,7 +233,8 @@ describe 'POST /categories/sort', autodoc: true do
     end
 
     it '200を返し、データが正しいこと' do
-      allow(Settings.user.categories).to receive(:maximum_length).and_return(5)
+      # NOTE: test環境のapplication.ymlで設定済み
+      allow(Settings.category).to receive(:maximum_size).and_return(5)
       post '/categories/sort', params: params, headers: login_headers(user)
       expect(response.status).to eq 200
 

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -41,7 +41,7 @@ describe 'GET /categories', autodoc: true do
             records_count: 0
           }
         ],
-        max_category_count: Settings.category.maximum_size
+        max_category_count: Settings.category.max_count
       }
       expect(response.body).to be_json_as(json)
     end
@@ -234,7 +234,7 @@ describe 'POST /categories/sort', autodoc: true do
 
     it '200を返し、データが正しいこと' do
       # NOTE: test環境のapplication.ymlで設定済み
-      allow(Settings.category).to receive(:maximum_size).and_return(5)
+      allow(Settings.category).to receive(:max_count).and_return(5)
       post '/categories/sort', params: params, headers: login_headers(user)
       expect(response.status).to eq 200
 

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -233,7 +233,6 @@ describe 'POST /categories/sort', autodoc: true do
     end
 
     it '200を返し、データが正しいこと' do
-      # NOTE: test環境のapplication.ymlで設定済み
       allow(Settings.category).to receive(:max_count).and_return(5)
       post '/categories/sort', params: params, headers: login_headers(user)
       expect(response.status).to eq 200

--- a/spec/requests/category/breakdowns_spec.rb
+++ b/spec/requests/category/breakdowns_spec.rb
@@ -31,7 +31,7 @@ describe 'GET /categories/:category_id/breakdowns', autodoc: true do
             name: breakdown.name
           }
         ],
-        max_breakdown_count: Settings.category.breakdowns.maximum_length
+        max_breakdown_count: Settings.breakdown.max_count
       }
       expect(response.body).to be_json_as(json)
     end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 describe 'GET /dashboard', autodoc: true do
   before do
-    allow(Settings.user.records).to receive(:maximum_length).and_return(5)
+    allow(Settings.record).to receive(:max_count).and_return(5)
   end
 
   let!(:user) { create(:email_user, :registered) }

--- a/spec/requests/place/categories_spec.rb
+++ b/spec/requests/place/categories_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 describe 'GET /places/:place_id/categories', autodoc: true do
   before do
     allow(Settings.category).to receive(:max_count).and_return(5)
-    # NOTE: test環境のapplication.ymlで設定済み
   end
   let!(:user) { create(:email_user, :registered) }
   let!(:place) { create(:place, user: user) }

--- a/spec/requests/place/categories_spec.rb
+++ b/spec/requests/place/categories_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 describe 'GET /places/:place_id/categories', autodoc: true do
   before do
-    allow(Settings.category).to receive(:maximum_size).and_return(5)
+    allow(Settings.category).to receive(:max_count).and_return(5)
     # NOTE: test環境のapplication.ymlで設定済み
   end
   let!(:user) { create(:email_user, :registered) }

--- a/spec/requests/place/categories_spec.rb
+++ b/spec/requests/place/categories_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 
 describe 'GET /places/:place_id/categories', autodoc: true do
   before do
-    allow(Settings.user.categories).to receive(:maximum_length).and_return(5)
+    allow(Settings.category).to receive(:maximum_size).and_return(5)
+    # NOTE: test環境のapplication.ymlで設定済み
   end
   let!(:user) { create(:email_user, :registered) }
   let!(:place) { create(:place, user: user) }

--- a/spec/requests/places_spec.rb
+++ b/spec/requests/places_spec.rb
@@ -39,7 +39,7 @@ describe 'GET /places', autodoc: true do
             ]
           }
         ],
-        max_place_count: Settings.user.places.maximum_length
+        max_place_count: Settings.place.max_count
       }
       expect(response.body).to be_json_as(json)
     end

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -311,7 +311,7 @@ describe 'GET /records/new', autodoc: true do
           tag_field: true,
           memo_field: true,
           currency: user.currency,
-          max_record_count: Settings.user.records.maximum_length
+          max_record_count: Settings.record.max_count
         }
       }
       expect(response.body).to be_json_as(json)


### PR DESCRIPTION
## 実施内容

Settingsの元の参照名（ex. `Settings.user.categories.maximum_length`）が長いので、`config/application.yml`を整理しました
- `Settings.user.categories.maximum_length`を`Settings.category.max_count`にしました
- `Settings.user.categories.admin_maximum_length`を`Settings.category.max_count_of_admin`にしました
- `Settings.user.places.maximum_length`を`Settings.place.max_count`にしました
- `Settings.user.places.admin_maximum_length`を`Settings.place.max_count_of_admin`にしました
- `Settings.user.records.maximum_length`を`Settings.record.max_count`にしました
- `Settings.user.records.admin_maximum_length`を`Settings.record.max_count_of_admin`にしました
- `Settings.category.breakdowns.maximum_length`を`Settings.breakdown.max_count`にしました
- `Settings.category.breakdowns.admin_maximum_length`を`Settings.breakdown.max_count`にしました
