### PR TITLE
管理者のカラムをテーブルに変更

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,0 +1,3 @@
+class Admin < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Admin < ApplicationRecord
   belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ActiveRecord::Base
   has_many :tallies
   has_many :captures
   has_many :breakdowns, through: :categories
+  has_one :admin
 
   enum status: { inactive: 1, registered: 2 }
 
@@ -55,6 +56,10 @@ class User < ActiveRecord::Base
 
   def authorize_new_email
     update(email: new_email, new_email: '')
+  end
+
+  def admin?
+    admin.present?
   end
 
   private

--- a/app/views/sessions/create.json.jbuilder
+++ b/app/views/sessions/create.json.jbuilder
@@ -8,7 +8,7 @@ json.user do
   json.nickname @user.nickname
   json.user_name @user.screen_name
   json.currency @user.currency
-  json.admin @user.admin
+  json.admin @user.admin?
 
   if @user.try(:auth)
     json.auth do

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -5,7 +5,7 @@ json.new_email @user.new_email
 json.nickname @user.nickname
 json.user_name @user.screen_name
 json.currency @user.currency
-json.admin @user.admin
+json.admin @user.admin?
 
 if @user.try(:auth)
   json.auth do

--- a/db/migrate/20161015151511_create_admins.rb
+++ b/db/migrate/20161015151511_create_admins.rb
@@ -1,0 +1,9 @@
+class CreateAdmins < ActiveRecord::Migration[5.0]
+  def change
+    create_table :admins do |t|
+      t.references :user
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20161015152610_remove_admin_from_users.rb
+++ b/db/migrate/20161015152610_remove_admin_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveAdminFromUsers < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :users, :admin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160921120022) do
+ActiveRecord::Schema.define(version: 20161015152610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "admins", force: :cascade do |t|
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_admins_on_user_id", using: :btree
+  end
 
   create_table "auths", force: :cascade do |t|
     t.integer  "user_id"
@@ -221,7 +228,6 @@ ActiveRecord::Schema.define(version: 20160921120022) do
     t.string   "token"
     t.string   "nickname"
     t.string   "type"
-    t.boolean  "admin"
     t.string   "code"
     t.integer  "status"
     t.string   "password_digest"

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -5,8 +5,7 @@ namespace :user do
       id = ENV['USER_ID']
       fail "ENV['USER_ID'] is not found." unless id
       user = User.find(id)
-      user.admin = true
-      user.save!
+      user.create_admin!
     rescue => ex
       puts ex.message
     end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe UserDecorator, type: :decorator do
 
   describe 'max count' do
     let!(:user) { create(:email_user, :registered).decorate }
-    let!(:admin_user) { create(:email_user, :registered, admin: true).decorate }
+    let!(:admin_user) { create(:email_user, :registered, :admin_user).decorate }
 
     shared_examples_for 'max count' do
       context 'admin is true' do

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :admin do
+    trait(:with_user) do
+      user
+    end
+  end
+end

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   factory :admin do
     trait(:with_user) do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,7 +28,7 @@ FactoryGirl.define do
     end
 
     trait :admin_user do
-      admin true
+      admin
     end
   end
 end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe Admin, type: :model do

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Admin, type: :model do
+  it { is_expected.to belong_to(:user) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe User, type: :model do
   it { is_expected.to have_many(:tags) }
   it { is_expected.to have_many(:tallies) }
   it { is_expected.to have_many(:captures) }
+  it { is_expected.to have_one(:admin) }
 
   describe 'バリデーション' do
     it { is_expected.to validate_length_of(:nickname).is_at_most(100) }

--- a/spec/requests/login_spec.rb
+++ b/spec/requests/login_spec.rb
@@ -25,7 +25,7 @@ describe 'POST /session?email=email&password=password', autodoc: true do
           nickname: user.nickname,
           user_name: user.screen_name,
           currency: user.currency,
-          admin: user.admin
+          admin: user.admin?
         }
       }
       expect(response.body).to be_json_as(json)

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -29,7 +29,7 @@ describe 'GET /user', autodoc: true do
         nickname: user.nickname,
         user_name: user.screen_name,
         currency: user.currency,
-        admin: user.admin
+        admin: user.admin?
       }
       expect(response.body).to be_json_as(json)
     end
@@ -50,7 +50,7 @@ describe 'GET /user', autodoc: true do
         nickname: user.nickname,
         user_name: user.screen_name,
         currency: user.currency,
-        admin: user.admin
+        admin: user.admin?
       }
       expect(response.body).to be_json_as(json)
     end
@@ -71,7 +71,7 @@ describe 'GET /user', autodoc: true do
         nickname: user.nickname,
         user_name: user.screen_name,
         currency: user.currency,
-        admin: user.admin,
+        admin: user.admin?,
         auth: {
           name: user.auth.name,
           screen_name: user.auth.screen_name
@@ -96,7 +96,7 @@ describe 'GET /user', autodoc: true do
         nickname: user.nickname,
         user_name: user.screen_name,
         currency: user.currency,
-        admin: user.admin,
+        admin: user.admin?,
         auth: {
           name: user.auth.name,
           screen_name: user.auth.screen_name


### PR DESCRIPTION
## 実施内容
- usersテーブルのadminカラムを削除し、adminsテーブルを作成しました
- 管理者権限を付与するrakeタスクを修正しました
## 対応理由
- 管理者の人数が少ないため、ほとんど使われないカラムがあるのを避けたいから
