### PR TITLE
マイページTOPに現在の登録数と最大登録可能数を返すように修正

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -8,6 +8,6 @@ class MypagesController < ApplicationController
     fetcher = Record::Fetcher
               .new(user: current_user, params: params, sort_type: 'lately')
     @records = fetcher.mypage
-    @user = current_user
+    @user = current_user.decorate
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -47,4 +47,8 @@ class UserDecorator < Draper::Decorator
   def max_record_count
     admin? ? Settings.record.max_count_of_admin : Settings.record.max_count
   end
+
+  def current_record_count
+    records.count
+  end
 end

--- a/app/views/mypages/show.json.jbuilder
+++ b/app/views/mypages/show.json.jbuilder
@@ -31,4 +31,6 @@ end
 
 json.user do
   json.currency @user.currency
+  json.current_record_count @user.current_record_count
+  json.max_record_count @user.max_record_count
 end

--- a/spec/requests/mypage_spec.rb
+++ b/spec/requests/mypage_spec.rb
@@ -10,7 +10,7 @@ describe 'GET /mypage', autodoc: true do
   end
 
   context 'ユーザーにお知らせとメッセージがある場合' do
-    let!(:user) { create(:email_user, :registered) }
+    let!(:user) { create(:email_user, :registered).decorate }
     let!(:user2) { create(:email_user, :registered) }
     let!(:notice1) { create(:notice, post_at: Time.zone.today) }
     let!(:notice2) { create(:notice, post_at: Time.zone.yesterday) }
@@ -90,7 +90,9 @@ describe 'GET /mypage', autodoc: true do
           }
         ],
         user: {
-          currency: user.currency
+          currency: user.currency,
+          current_record_count: user.records.count,
+          max_record_count: user.max_record_count
         }
       }
       expect(response.body).to be_json_as(json)


### PR DESCRIPTION
## 対応内容

マイページTOPを表示するAPIのjsonデータに、以下の値を追加しました
- 現在の登録数
- 作成可能な最大登録数
