### PR TITLE
マイページTOPに登録数をあらわすグラフを追加

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -32,7 +32,7 @@ defaults: &defaults
     name:
       maximum_length: 100
   record:
-    max_count: 200
+    max_count: 500
     max_count_of_admin: 9999
     memo:
       maximum_length: 10000

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -365,3 +365,10 @@ body {
 .color-picker-wrapper .input-group { 
   width: 40%;
 }
+
+.progress {
+  background-color: rgba(#fff, 0.4);
+}
+.progress-bar-success {
+ background-color: lighten($green, 35%);
+}

--- a/src/app/user/mypage/mypage.controller.coffee
+++ b/src/app/user/mypage/mypage.controller.coffee
@@ -8,6 +8,8 @@ MypageController = (UserFactory, IndexService, $uibModal, RecordsFactory) ->
     vm.messages = res.messages
     vm.records = res.records
     vm.user = res.user
+    vm.max = String(res.user.max_record_count)
+    vm.bar_value = String(res.user.current_record_count)
     IndexService.loading = false
   ).catch (res) ->
     IndexService.loading = false

--- a/src/app/user/mypage/mypage.jade
+++ b/src/app/user/mypage/mypage.jade
@@ -35,6 +35,14 @@
               a(href='' ng-click='mypage.destroyRecord($index)')
                 span.glyphicon.glyphicon-trash.green(uib-tooltip="{{'TOOLTIPS.DELETE' | translate}}")
 
+         div
+
+         uib-progressbar(type='success' class='progress-striped green' max='mypage.max' value='mypage.bar_value'
+                         uib-tooltip="{{ 'TOOLTIPS.RECORD_COUNT' | translate }} {{ mypage.bar_value }} / {{ mypage.max }}")
+           span#left-icon
+           span.green.glyphicon.glyphicon-piggy-bank#left-icon
+           span.green {{ mypage.bar_value }} / {{ mypage.max }}
+
   // お知らせ
   .col-md-6
     .panel.panel-default

--- a/src/app/user/mypage/mypage.jade
+++ b/src/app/user/mypage/mypage.jade
@@ -35,8 +35,6 @@
               a(href='' ng-click='mypage.destroyRecord($index)')
                 span.glyphicon.glyphicon-trash.green(uib-tooltip="{{'TOOLTIPS.DELETE' | translate}}")
 
-         div
-
          uib-progressbar(type='success' class='progress-striped green' max='mypage.max' value='mypage.bar_value'
                          uib-tooltip="{{ 'TOOLTIPS.RECORD_COUNT' | translate }} {{ mypage.bar_value }} / {{ mypage.max }}")
            span#left-icon

--- a/src/assets/i18n/locale-en.json
+++ b/src/assets/i18n/locale-en.json
@@ -107,7 +107,8 @@
     "SET_CATEGORY": "Add a Category to the Shop",
     "TAGS_QUESTION": "You can use 'esc' key when don't select",
     "BREAKDOWNS": "Breakdowns",
-    "PLACES": "Shops & Locations"
+    "PLACES": "Shops & Locations",
+    "RECORD_COUNT": "Record Number"
   },
   "LINKS": {
     "DISPLAY_SETTING": ">>> Display Settings",

--- a/src/assets/i18n/locale-ja.json
+++ b/src/assets/i18n/locale-ja.json
@@ -108,7 +108,8 @@
     "SET_CATEGORY": "カテゴリを設定",
     "TAGS_QUESTION": "escキーで候補を非表示にできます。候補から選択しない場合にご利用ください",
     "BREAKDOWNS": "内訳",
-    "PLACES": "お店・施設"
+    "PLACES": "お店・施設",
+    "RECORD_COUNT": "登録数"
   },
   "LINKS": {
     "DISPLAY_SETTING": ">>> 各項目の表示設定",


### PR DESCRIPTION
#40 の対応です。
## 実施内容

マイページTOPに登録数の割合を表すグラフを追加しました。

<img width="838" alt="2016-10-16 13 13 38" src="https://cloud.githubusercontent.com/assets/1570530/19415321/c1a7122a-93a7-11e6-9562-abddbdb8c7ca.png">
