### PR TITLE
カテゴリ一覧にカテゴリ作成上限数を表示

### DIFF
--- a/src/app/settings/category/categories.jade
+++ b/src/app/settings/category/categories.jade
@@ -77,3 +77,5 @@
               input.category-form(name='name' ng-model='categories.new_category_name' auto-focus=true type='text' required=true ng-maxlength='100')
             button.btn.btn-success(translate='BUTTONS.ADD' ng-disabled='newCategoryForm.$dirty && newCategoryForm.$invalid')
             a.btn.btn-default.pull-right(translate='BUTTONS.CANCEL' ng-click='categories.add_field = false')
+    p
+      span {{ 'LABELS.CATEGORY_COUNT' | translate }} : {{ categories.categories.length }} / {{ categories.max_category_count }}

--- a/src/assets/i18n/locale-en.json
+++ b/src/assets/i18n/locale-en.json
@@ -73,6 +73,7 @@
     "ADD_RECORDS": "Records",
     "BREAKDOWNS": "Breakdowns",
     "CSV_FILE": "CSV File",
+    "CATEGORY_COUNT": "Category number",
     "DOWNLOAD": "Download : ",
     "FEEDBACK": "Feedback",
     "FEEDBACK_EMAIL": "your Email address",

--- a/src/assets/i18n/locale-ja.json
+++ b/src/assets/i18n/locale-ja.json
@@ -74,6 +74,7 @@
     "ADD_RECORDS": "の登録",
     "BREAKDOWNS": "内訳",
     "CSV_FILE": "CSVファイル",
+    "CATEGORY_COUNT": "カテゴリ数",
     "DOWNLOAD": "ダウンロード：",
     "FEEDBACK": "フィードバック",
     "FEEDBACK_EMAIL": "連絡先メールアドレス",


### PR DESCRIPTION
## 対応内容
#57 の対応です。

カテゴリの作成上限数と現在のカテゴリ数をカテゴリ一覧画面に表示するようにしました
## 対応理由
- カテゴリに作成上限数があることを示すため
- 現在のカテゴリ数を表示するため
