### PR TITLE
インポート履歴一覧の更新した行にアニメーションを追加

### DIFF
--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -370,5 +370,18 @@ body {
   background-color: rgba(#fff, 0.4);
 }
 .progress-bar-success {
- background-color: lighten($green, 35%);
+  background-color: lighten($green, 35%);
+}
+
+.highright-add {
+  -webkit-transition: linear 1s;
+  -moz-transition: linear 1s;
+  -ms-transition: linear 1s;
+  -o-transition: linear 1s;
+  transition: linear 1s;
+  background-color: rgba(#fff, 0.6);
+}
+
+.highright-add-active{
+  background-color: transparent;
 }

--- a/src/app/user/import/import_history.controller.coffee
+++ b/src/app/user/import/import_history.controller.coffee
@@ -1,4 +1,4 @@
-ImportHistoryController = (IndexService, ImportFactory, $uibModal, $translate, RecordsFactory, $timeout) ->
+ImportHistoryController = (IndexService, ImportFactory, $uibModal, $translate, RecordsFactory) ->
   'ngInject'
   vm = this
 

--- a/src/app/user/import/import_history.controller.coffee
+++ b/src/app/user/import/import_history.controller.coffee
@@ -1,8 +1,9 @@
-ImportHistoryController = (IndexService, ImportFactory, $uibModal, $translate, RecordsFactory) ->
+ImportHistoryController = (IndexService, ImportFactory, $uibModal, $translate, RecordsFactory, $timeout) ->
   'ngInject'
   vm = this
 
   vm.selectLineNumber = undefined
+  vm.updateAnimate = 'highright'
 
   getCaptures = () ->
     IndexService.loading = true
@@ -77,6 +78,7 @@ ImportHistoryController = (IndexService, ImportFactory, $uibModal, $translate, R
     ImportFactory.getCapture(capture.id).then (res) ->
       vm.captures[index] = res
       capture.loading = false
+      vm.updateAnimate = 'highright'
 
   # 「glyphicon-trash」リンク
   vm.destroyCapture = (index) ->

--- a/src/app/user/import/import_history.jade
+++ b/src/app/user/import/import_history.jade
@@ -36,7 +36,8 @@
         th
         th
       tr(ng-repeat='capture in import_history.captures'
-         ng-mouseover='import_history.selectLine($index)')
+         ng-mouseover='import_history.selectLine($index)'
+         ng-class="import_history.updateAnimate")
         td.line-color(ng-class="{ 'line-color-red': import_history.selectLineNumber == $index}")
         td {{ capture.published_at | date:'yyyy-MM-dd' }}
         td
@@ -65,7 +66,8 @@
         td
           span.red {{ capture.comment }}
         td
-          button.btn.btn-success.btn-sm(ng-disabled='capture.registered || capture.loading' ng-click='import_history.reloadCapture($index)')
+          button.btn.btn-success.btn-sm(ng-disabled='capture.registered || capture.loading'
+                                        ng-click='import_history.reloadCapture($index)')
             span.glyphicon.glyphicon-repeat
         td
           button.btn.btn-info.btn-sm(ng-hide='capture.registered' ng-click='import_history.showCapture($index)')


### PR DESCRIPTION
## 対応内容
#55 の対応です。

インポート履歴一覧で、各行ごとの更新のタイミングでアニメーションで表示するようにしました
![reload-button](https://cloud.githubusercontent.com/assets/1570530/19447130/0def753e-94d7-11e6-9ad5-200dc1b2c9d6.gif)
## 対応理由

どの行が更新されたかをわかりやすくするため
