### PR TITLE
月末月初のみ、グラフに統計を返さないバグを修正

### DIFF
--- a/app/models/tally.rb
+++ b/app/models/tally.rb
@@ -23,7 +23,7 @@ class Tally < ActiveRecord::Base
     to = from.end_of_month
 
     records = user.records.joins(:category)
-                  .where('published_at > ? and published_at < ?', from, to)
+                  .where('published_at >= ? and published_at <= ?', from, to)
                   .pluck("date_trunc('day', published_at) as published",
                          :charge, :barance_of_payments)
     records.group_by { |i| i[0].to_s.slice(0, 10) }


### PR DESCRIPTION
## 事象

月末月初のみ、グラフに統計を返していませんでした。

## 再現方法

月末月初で、統計を返すテストに失敗していたことで発覚です。

## 対応内容

原因は、対象の一月分の範囲に月末月初が含まれていないことであったため
条件を修正しました。

