### PR TITLE
2017年になって、「リスト」画面が表示されなくなった問題を修正

### DIFF
--- a/src/app/index.route.coffee
+++ b/src/app/index.route.coffee
@@ -118,19 +118,19 @@ angular.module 'newAccountBook'
         controller: 'RecordsController'
       # リスト画面（年）
       .state 'yearly_list',
-        url: '/list/{year:201[2-6]+}?category_id&breakdown_id&place_id'
+        url: '/list/{year:201[0-9]+}?category_id&breakdown_id&place_id'
         templateUrl: 'app/records/list/list.html'
         controllerAs: 'list'
         controller: 'RecordsController'
       # リスト画面（月）
       .state 'monthly_list',
-        url: '/list/{year:201[2-6]+}/{month:[0|1]*[0-9]+}?category_id&breakdown_id&place_id'
+        url: '/list/{year:201[0-9]+}/{month:[0|1]*[0-9]+}?category_id&breakdown_id&place_id'
         templateUrl: 'app/records/list/list.html'
         controllerAs: 'list'
         controller: 'RecordsController'
       # リスト画面（日）
       .state 'daily_list',
-        url: '/list/{year:201[2-6]+}/{month:[0|1]*[0-9]+}/{day:[0-9]{1,2}}?category_id&breakdown_id&place_id'
+        url: '/list/{year:201[0-9]+}/{month:[0|1]*[0-9]+}/{day:[0-9]{1,2}}?category_id&breakdown_id&place_id'
         templateUrl: 'app/records/list/list.html'
         controllerAs: 'list'
         controller: 'RecordsController'


### PR DESCRIPTION
## 事象

メニュー「リスト」をクリックしても、リスト画面が表示されない。

## 再現方法

1. メニュー「リスト」をクリックする
2. ホーム画面に遷移される

## 対応内容

- 許可する対象のURLの正規表現に2017年が該当しないものになっていました。
正規表現の幅を広げました