### PR TITLE
timecopを使い、時間のテストで落ちないように修正

### DIFF
--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -23,7 +23,7 @@ describe 'GET /admin/users', autodoc: true do
 
   context '管理ユーザーとしてログインしている場合' do
     context '1ページ以内のユーザー数の場合' do
-      let(:sign_in_at) { I18n.l(Time.zone.now) }
+      let(:sign_in_at) { Time.zone.now }
       before do
         Timecop.freeze(sign_in_at)
       end
@@ -43,7 +43,7 @@ describe 'GET /admin/users', autodoc: true do
               status: admin_user.human_status_name,
               nickname: admin_user.nickname,
               email: admin_user.email,
-              last_sign_in_at: sign_in_at
+              last_sign_in_at: I18n.l(sign_in_at)
             },
             {
               id: user.id,

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -23,6 +23,11 @@ describe 'GET /admin/users', autodoc: true do
 
   context '管理ユーザーとしてログインしている場合' do
     context '1ページ以内のユーザー数の場合' do
+      let(:sign_in_at) { I18n.l(Time.zone.now) }
+      before do
+        Timecop.freeze(sign_in_at)
+      end
+
       it '200が返り、ユーザー一覧が返ってくること' do
         get '/admin/users/', params: '', headers: login_headers(admin_user)
 
@@ -38,7 +43,7 @@ describe 'GET /admin/users', autodoc: true do
               status: admin_user.human_status_name,
               nickname: admin_user.nickname,
               email: admin_user.email,
-              last_sign_in_at: I18n.l(Time.zone.now)
+              last_sign_in_at: sign_in_at
             },
             {
               id: user.id,
@@ -81,6 +86,10 @@ describe 'GET /admin/users', autodoc: true do
           total_count: 2
         }
         expect(response.body).to be_json_as(json)
+      end
+
+      after do
+        Timecop.return
       end
     end
   end


### PR DESCRIPTION
## 対応内容

admin_userのアクセス時間をtimecopで固定し、時間によるテストで落ちないようにしました。

## 対応理由

issue #150 
