### PR TITLE
不足していたバリデーションを追加

### DIFF
--- a/app/controllers/admin/user/messages_controller.rb
+++ b/app/controllers/admin/user/messages_controller.rb
@@ -5,7 +5,7 @@ class Admin::User::MessagesController < ApplicationController
 
   def create
     user = User.find(params[:user_id])
-    @message = user.messages.new(message_params)
+    @message = user.messages.new(message_params.merge(sent_at: Time.zone.now))
     if @message.save
       head 201
     else

--- a/app/controllers/captures_controller.rb
+++ b/app/controllers/captures_controller.rb
@@ -42,7 +42,7 @@ class CapturesController < ApplicationController
   private
 
   def capture_params
-    params.permit(:published_at, :category_name, :breakdown_name, :place_name,
+    params.permit(:published_on, :category_name, :breakdown_name, :place_name,
                   :charge, :memo, :tags)
   end
 end

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -10,7 +10,7 @@ class PlacesController < ApplicationController
   end
 
   def create
-    place = current_user.places.new(place_params)
+    place = current_user.places.build(place_params)
     if place.save
       head 201
     else

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -76,7 +76,7 @@ class RecordsController < ApplicationController
   private
 
   def record_params
-    params.permit(:published_at, :charge, :memo,
+    params.permit(:published_on, :charge, :memo,
                   :category_id, :breakdown_id, :place_id)
   end
 

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 class Admin < ApplicationRecord
   belongs_to :user
+
+  validates :user_id, presence: true, uniqueness: true
 end

--- a/app/models/auth.rb
+++ b/app/models/auth.rb
@@ -2,4 +2,7 @@
 class Auth < ActiveRecord::Base
   belongs_to :twitter_user, foreign_key: 'user_id'
   belongs_to :facebook_user, foreign_key: 'user_id'
+
+  validates :user_id, presence: true
+  validates :provider, presence: true, inclusion: %w(twitter facebook)
 end

--- a/app/models/breakdown.rb
+++ b/app/models/breakdown.rb
@@ -7,4 +7,5 @@ class Breakdown < ActiveRecord::Base
 
   validates :name, presence: true,
                    length: { maximum: Settings.breakdown.name.maximum_length }
+  validates :category_id, presence: true
 end

--- a/app/models/capture.rb
+++ b/app/models/capture.rb
@@ -5,7 +5,7 @@ class Capture < ApplicationRecord
   belongs_to :breakdown, optional: true
   belongs_to :place, optional: true
 
-  validates :published_at, presence: true
+  validates :published_on, presence: true
   validates :category_name,
             presence: true,
             length: { maximum: Settings.category.name.maximum_length }

--- a/app/models/capture/updator.rb
+++ b/app/models/capture/updator.rb
@@ -10,7 +10,7 @@ class Capture::Updator
   def import
     @lines.each do |line|
       next if line.first.empty?
-      capture = @user.captures.new(published_at: line[0], memo: line[5],
+      capture = @user.captures.new(published_on: line[0], memo: line[5],
                                    category_name: line[1], place_name: line[3],
                                    breakdown_name: line[2], charge: line[4],
                                    tags: line[6..-1].try(:join, ','))

--- a/app/models/categorize_place.rb
+++ b/app/models/categorize_place.rb
@@ -4,6 +4,8 @@ class CategorizePlace < ActiveRecord::Base
   belongs_to :category
   belongs_to :place
 
+  validates :category_id, presence: true
+  validates :place_id, presence: true
   validates :category_id, uniqueness: { scope: :place_id }
   # validates :place, uniqueness: { scope: :category_id }
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -14,7 +14,6 @@ class Category < ActiveRecord::Base
             length: { maximum: Settings.breakdown.max_count,
                       too_long: I18n.t('errors.messages.too_many') }
   validates :user_id, presence: true
-  validates :position, presence: true
   validates :barance_of_payments, inclusion: { in: [true, false] }
   validate :should_be_less_than_maximum, on: :create
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -13,6 +13,9 @@ class Category < ActiveRecord::Base
   validates :breakdowns,
             length: { maximum: Settings.breakdown.max_count,
                       too_long: I18n.t('errors.messages.too_many') }
+  validates :user_id, presence: true
+  validates :position, presence: true
+  validates :barance_of_payments, inclusion: { in: [true, false] }
   validate :should_be_less_than_maximum, on: :create
 
   before_create :set_position

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -8,6 +8,7 @@ class Feedback < ActiveRecord::Base
             length: { maximum: Settings.feedback.content.maximum_length }
   validates :email,
             presence: true,
+            email_format: { allow_blank: true },
             length: { maximum: Settings.feedback.email.maximum_length },
             unless: 'email.nil?'
 

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -6,10 +6,12 @@ class Place < ActiveRecord::Base
   has_many :records
   has_many :captures
 
+  validates :user_id, presence: true
   validates :name,
             presence: true,
+            uniqueness: { scope: :user_id, case_sensitive: true },
             length: { maximum: Settings.place.name.maximum_length }
-  validate :should_be_less_than_maximum, on: :create
+  before_create :should_be_less_than_maximum
 
   def categorize?(category_id)
     categories.map(&:id).include?(category_id)
@@ -26,7 +28,7 @@ class Place < ActiveRecord::Base
     if maximum_count <= user.places.count
       errors[:base] <<
         I18n.t('errors.messages.places.too_many', count: maximum_count)
+      throw :abort
     end
-    true
   end
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -20,15 +20,13 @@ class Place < ActiveRecord::Base
   private
 
   def should_be_less_than_maximum
-    maximum_count = if user.admin
-                      Settings.place.max_count_of_admin
-                    else
-                      Settings.place.max_count
-                    end
+    maximum_count =
+      user.admin ? Settings.place.max_count_of_admin : Settings.place.max_count
     if maximum_count <= user.places.count
       errors[:base] <<
         I18n.t('errors.messages.places.too_many', count: maximum_count)
       throw :abort
     end
+    true
   end
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -10,6 +10,7 @@ class Record < ActiveRecord::Base
   has_many :tags, through: :tagged_records
 
   validates :published_at, presence: true
+  validates :user_id, presence: true
   validates :charge, presence: true,
                      numericality: { only_integer: true,
                                      greater_than_or_equal_to: 0,

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -9,7 +9,7 @@ class Record < ActiveRecord::Base
   has_many :tagged_records
   has_many :tags, through: :tagged_records
 
-  validates :published_at, presence: true
+  validates :published_on, presence: true
   validates :user_id, presence: true
   validates :charge, presence: true,
                      numericality: { only_integer: true,
@@ -20,12 +20,12 @@ class Record < ActiveRecord::Base
   validates :memo, length: { maximum: Settings.record.memo.maximum_length }
   validate :should_be_less_than_maximum, on: :create
 
-  scope :the_day, ->(target_day) { where(published_at: target_day.to_date) }
+  scope :the_day, ->(target_day) { where(published_on: target_day.to_date) }
   scope :the_month, lambda { |first_day|
-    where(published_at: first_day..first_day.end_of_month)
+    where(published_on: first_day..first_day.end_of_month)
   }
   scope :the_year, lambda { |first_day|
-    where(published_at: first_day..first_day.end_of_year)
+    where(published_on: first_day..first_day.end_of_year)
   }
 
   def update_with_tags(record_params, tags_params)

--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -16,7 +16,7 @@ class Record::Fetcher
   end
 
   def all
-    records = @user.records.order(published_at: :desc, created_at: :desc)
+    records = @user.records.order(published_on: :desc, created_at: :desc)
     records = find_by_date(records)
     records = find_by_refine(records)
     set_refine_word
@@ -31,7 +31,7 @@ class Record::Fetcher
   end
 
   def all_as_csv
-    records = @user.records.order(:published_at)
+    records = @user.records.order(:published_on)
     records = find_by_date(records)
     find_by_refine(records)
   end

--- a/app/models/record/generator.rb
+++ b/app/models/record/generator.rb
@@ -15,7 +15,7 @@ class Record::Generator
   def build
     @capture = @user.captures.find(@capture_id)
     @record_params = {
-      published_at: @capture.published_on, memo: @capture.memo,
+      published_on: @capture.published_on, memo: @capture.memo,
       category_id: @capture.category_id, breakdown_id: @capture.breakdown_id,
       place_id: @capture.place_id, charge: @capture.charge || 0
     }

--- a/app/models/record/generator.rb
+++ b/app/models/record/generator.rb
@@ -15,7 +15,7 @@ class Record::Generator
   def build
     @capture = @user.captures.find(@capture_id)
     @record_params = {
-      published_at: @capture.published_at, memo: @capture.memo,
+      published_at: @capture.published_on, memo: @capture.memo,
       category_id: @capture.category_id, breakdown_id: @capture.breakdown_id,
       place_id: @capture.place_id, charge: @capture.charge || 0
     }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -5,6 +5,7 @@ class Tag < ActiveRecord::Base
   has_many :tagged_records
   has_many :records, through: :tagged_records
 
+  validates :user_id, presence: true
   validates :name,
             presence: true,
             uniqueness: { scope: :user_id },

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -9,6 +9,10 @@ class Tag < ActiveRecord::Base
             presence: true,
             uniqueness: { scope: :user_id },
             length: { maximum: Settings.tag.name.maximum_length }
+  validates :color_code,
+            uniqueness: { scope: :user_id },
+            format: { with: /\A\#[\w]{6}\Z/i },
+            allow_nil: true
 
   before_save :set_color_code
 

--- a/app/models/tagged_record.rb
+++ b/app/models/tagged_record.rb
@@ -2,4 +2,8 @@
 class TaggedRecord < ActiveRecord::Base
   belongs_to :tag
   belongs_to :record
+
+  validates :tag_id, presence: true
+  validates :record_id, presence: true
+  validates :record_id, uniqueness: { scope: :tag_id }
 end

--- a/app/models/tally.rb
+++ b/app/models/tally.rb
@@ -25,8 +25,8 @@ class Tally < ActiveRecord::Base
     to = from.end_of_month
 
     records = user.records.joins(:category)
-                  .where('published_at >= ? and published_at <= ?', from, to)
-                  .pluck("date_trunc('day', published_at) as published",
+                  .where('published_on >= ? and published_on <= ?', from, to)
+                  .pluck("date_trunc('day', published_on) as published",
                          :charge, :barance_of_payments)
     records.group_by { |i| i[0].to_s.slice(0, 10) }
   end

--- a/app/models/tally.rb
+++ b/app/models/tally.rb
@@ -3,6 +3,8 @@ class Tally < ActiveRecord::Base
   belongs_to :user
   serialize :list, JSON
 
+  validates :user_id, :year, presence: true
+
   attr_accessor :plus_count, :minus_count
 
   def update_list(year, month)

--- a/app/models/twitter_user.rb
+++ b/app/models/twitter_user.rb
@@ -3,14 +3,14 @@ class TwitterUser < User
   has_one :auth, foreign_key: 'user_id'
 
   def self.create_with(auth)
-    twitter_user = create!(status: :inactive)
-    auth_data = Auth.create!(
+    twitter_user = new(status: :inactive)
+    twitter_user.auth = Auth.new(
       provider: 'twitter',
       uid: auth['uid'],
       screen_name: auth['info']['nickname'],
       name: auth['info']['name']
     )
-    twitter_user.auth = auth_data
+    twitter_user.save!
     twitter_user
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,8 @@ class User < ActiveRecord::Base
   validates :nickname,
             length: { maximum: Settings.user.nickname.maximum_length }
   # TODO: ユーザーのランクによって制限数を変更する
+  # TODO: 作成上限数をvalidatesを設定できるようにする
+  # validates :places, length: { maximum: MAX_PLACES_LENGTH, message: MESSAGES }
 
   before_create :set_currency
 

--- a/app/views/captures/index.json.jbuilder
+++ b/app/views/captures/index.json.jbuilder
@@ -2,7 +2,7 @@ json.captures do
   json.array! @captures do |capture|
     json.id capture.id
     json.created_at I18n.l(capture.created_at)
-    json.published_at capture.published_at
+    json.published_on capture.published_on
     json.category_name capture.category_name
     json.category_payments capture.category.try(:barance_of_payments)
     json.category_id capture.category_id

--- a/app/views/captures/show.json.jbuilder
+++ b/app/views/captures/show.json.jbuilder
@@ -1,6 +1,6 @@
 json.id @capture.id
 json.created_at I18n.l(@capture.created_at)
-json.published_at @capture.published_at
+json.published_on @capture.published_on
 json.category_name @capture.category_name
 json.category_payments @capture.category.try(:barance_of_payments)
 json.category_id @capture.category_id

--- a/app/views/mypages/show.json.jbuilder
+++ b/app/views/mypages/show.json.jbuilder
@@ -19,7 +19,7 @@ end
 json.records do
   json.array! @records do |record|
     json.id record.id
-    json.published_at record.published_at
+    json.published_on record.published_on
     json.charge record.charge
     json.payments record.category.barance_of_payments
     json.category_name record.category.name

--- a/app/views/records/edit.json.jbuilder
+++ b/app/views/records/edit.json.jbuilder
@@ -30,7 +30,7 @@ end
 
 json.record do
   json.id @record.id
-  json.published_at @record.published_at
+  json.published_on @record.published_on
   json.payments @record.category.barance_of_payments
   json.charge @record.charge
   json.category_name @record.category.name

--- a/app/views/records/export.csv.ruby
+++ b/app/views/records/export.csv.ruby
@@ -3,7 +3,7 @@ require 'csv'
 CSV.generate do |csv|
   @records.each do |record|
     csv << [
-      record.published_at,
+      record.published_on,
       record.category.try!(:name),
       record.breakdown.try!(:name),
       record.place.try!(:name),

--- a/app/views/records/index.json.jbuilder
+++ b/app/views/records/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.records do
   json.array! @records do |record|
     json.id record.id
-    json.published_at record.published_at
+    json.published_on record.published_on
     json.payments record.category.barance_of_payments
     json.charge record.charge
     json.category_id record.category.id

--- a/app/views/records/show.json.jbuilder
+++ b/app/views/records/show.json.jbuilder
@@ -1,5 +1,5 @@
 json.id @record.id
-json.published_at @record.published_at
+json.published_on @record.published_on
 json.payments @record.category.barance_of_payments
 json.charge @record.charge
 json.category_name @record.category.name

--- a/config/locales/activerecord_ja.yml
+++ b/config/locales/activerecord_ja.yml
@@ -2,7 +2,7 @@ ja:
   activerecord:
     attributes:
       capture:
-        published_at: 日付
+        published_on: 日付
         category_name: カテゴリ名
         breakdown_name: 内訳
         place_name: お店・施設名

--- a/db/migrate/20170202014610_change_columns_to_tags.rb
+++ b/db/migrate/20170202014610_change_columns_to_tags.rb
@@ -1,0 +1,19 @@
+class ChangeColumnsToTags < ActiveRecord::Migration[5.0]
+  def up
+    change_column :tags, :name, :string, null: false
+    change_column :tags, :color_code, :string, null: false
+    change_column :tags, :user_id, :integer, null: false
+
+    add_index :tags, [:user_id, :name], unique: true
+    add_index :tags, [:user_id, :color_code], unique: true
+  end
+
+  def down
+    change_column :tags, :name, :string, null: true
+    change_column :tags, :color_code, :string, null: true
+    change_column :tags, :user_id, :integer, null: true
+
+    remove_index :tags, [:user_id, :name]
+    remove_index :tags, [:user_id, :color_code]
+  end
+end

--- a/db/migrate/20170202022635_change_columns_to_admins.rb
+++ b/db/migrate/20170202022635_change_columns_to_admins.rb
@@ -1,11 +1,9 @@
 class ChangeColumnsToAdmins < ActiveRecord::Migration[5.0]
   def up
     change_column :admins, :user_id, :integer, null: false
-    add_index :admins, :user_id, unique: true
   end
 
   def down
     change_column :admins, :user_id, :integer, null: true
-    remove_index :admins, :user_id
   end
 end

--- a/db/migrate/20170202022635_change_columns_to_admins.rb
+++ b/db/migrate/20170202022635_change_columns_to_admins.rb
@@ -1,0 +1,11 @@
+class ChangeColumnsToAdmins < ActiveRecord::Migration[5.0]
+  def up
+    change_column :admins, :user_id, :integer, null: false
+    add_index :admins, :user_id, unique: true
+  end
+
+  def down
+    change_column :admins, :user_id, :integer, null: true
+    remove_index :admins, :user_id
+  end
+end

--- a/db/migrate/20170202140912_remove_post_type_from_notices.rb
+++ b/db/migrate/20170202140912_remove_post_type_from_notices.rb
@@ -1,0 +1,5 @@
+class RemovePostTypeFromNotices < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :notices, :post_type, :string
+  end
+end

--- a/db/migrate/20170204021228_change_columns_to_places.rb
+++ b/db/migrate/20170204021228_change_columns_to_places.rb
@@ -1,0 +1,15 @@
+class ChangeColumnsToPlaces < ActiveRecord::Migration[5.0]
+  def up
+    change_column :places, :name, :string, null: false
+    change_column :places, :user_id, :integer, null: false
+
+    add_index :places, [:user_id, :name], unique: true
+  end
+
+  def down
+    change_column :places, :name, :string, null: true
+    change_column :places, :user_id, :integer, null: true
+
+    remove_index :places, [:user_id, :name]
+  end
+end

--- a/db/migrate/20170204030018_change_columns_to_cancels.rb
+++ b/db/migrate/20170204030018_change_columns_to_cancels.rb
@@ -1,0 +1,11 @@
+class ChangeColumnsToCancels < ActiveRecord::Migration[5.0]
+  def up
+    change_column :cancels, :user_id, :integer, null: false
+    change_column :cancels, :content, :text, null: false
+  end
+
+  def down
+    change_column :cancels, :user_id, :integer, null: true
+    change_column :cancels, :content, :text, null: true
+  end
+end

--- a/db/migrate/20170204030651_change_columns_to_categorize_places.rb
+++ b/db/migrate/20170204030651_change_columns_to_categorize_places.rb
@@ -1,0 +1,15 @@
+class ChangeColumnsToCategorizePlaces < ActiveRecord::Migration[5.0]
+  def up
+    change_column :categorize_places, :category_id, :integer, null: false
+    change_column :categorize_places, :place_id, :integer, null: false
+
+    add_index :categorize_places, [:category_id, :place_id], unique: true
+  end
+
+  def down
+    change_column :categorize_places, :category_id, :integer, null: true
+    change_column :categorize_places, :place_id, :integer, null: true
+
+    remove_index :categorize_places, [:category_id, :place_id]
+  end
+end

--- a/db/migrate/20170204084638_change_columns_to_records.rb
+++ b/db/migrate/20170204084638_change_columns_to_records.rb
@@ -1,0 +1,15 @@
+class ChangeColumnsToRecords < ActiveRecord::Migration[5.0]
+  def up
+    change_column :records, :published_at, :date, null: false
+    change_column :records, :category_id, :integer, null: false
+    change_column :records, :charge, :integer, null: false
+    change_column :records, :user_id, :integer, null: false
+  end
+
+  def down
+    change_column :records, :published_at, :date, null: true
+    change_column :records, :category_id, :integer, null: true
+    change_column :records, :charge, :integer, null: true
+    change_column :records, :user_id, :integer, null: true
+  end
+end

--- a/db/migrate/20170204084638_change_columns_to_records.rb
+++ b/db/migrate/20170204084638_change_columns_to_records.rb
@@ -4,12 +4,14 @@ class ChangeColumnsToRecords < ActiveRecord::Migration[5.0]
     change_column :records, :category_id, :integer, null: false
     change_column :records, :charge, :integer, null: false
     change_column :records, :user_id, :integer, null: false
+    rename_column :records, :published_at, :published_on
   end
 
   def down
-    change_column :records, :published_at, :date, null: true
+    change_column :records, :published_on, :date, null: true
     change_column :records, :category_id, :integer, null: true
     change_column :records, :charge, :integer, null: true
     change_column :records, :user_id, :integer, null: true
+    rename_column :records, :published_on, :published_at
   end
 end

--- a/db/migrate/20170205150528_change_columns_to_auths.rb
+++ b/db/migrate/20170205150528_change_columns_to_auths.rb
@@ -1,0 +1,11 @@
+class ChangeColumnsToAuths < ActiveRecord::Migration[5.0]
+  def up
+    change_column :auths, :user_id, :integer, null: false
+    change_column :auths, :provider, :string, null: false
+  end
+
+  def down
+    change_column :auths, :user_id, :integer, null: true
+    change_column :auths, :provider, :string, null: true
+  end
+end

--- a/db/migrate/20170205152813_change_columns_to_tagged_records.rb
+++ b/db/migrate/20170205152813_change_columns_to_tagged_records.rb
@@ -1,0 +1,15 @@
+class ChangeColumnsToTaggedRecords < ActiveRecord::Migration[5.0]
+  def up
+    change_column :tagged_records, :tag_id, :integer, null: false, index: true
+    change_column :tagged_records, :record_id, :integer, null: false, index: true
+
+    add_index :tagged_records, [:record_id, :tag_id], unique: true
+  end
+
+  def down
+    change_column :tagged_records, :tag_id, :integer, null: true
+    change_column :tagged_records, :record_id, :integer, null: true
+
+    remove_index :tagged_records, [:record_id, :tag_id]
+  end
+end

--- a/db/migrate/20170205160016_change_columns_to_categories.rb
+++ b/db/migrate/20170205160016_change_columns_to_categories.rb
@@ -1,0 +1,15 @@
+class ChangeColumnsToCategories < ActiveRecord::Migration[5.0]
+  def up
+    change_column :categories, :name, :string, null: false
+    change_column :categories, :user_id, :integer, null: false
+    change_column :categories, :position, :integer, null: false
+    change_column :categories, :barance_of_payments, :boolean, default: false, null: false
+  end
+
+  def down
+    change_column :categories, :name, :string, null: true
+    change_column :categories, :user_id, :integer, null: true
+    change_column :categories, :position, :integer, null: true
+    change_column :categories, :barance_of_payments, :boolean, null: true
+  end
+end

--- a/db/migrate/20170205162938_change_columns_to_messages.rb
+++ b/db/migrate/20170205162938_change_columns_to_messages.rb
@@ -1,0 +1,17 @@
+class ChangeColumnsToMessages < ActiveRecord::Migration[5.0]
+  def up
+    change_column :messages, :user_id, :integer, null: false
+    change_column :messages, :content, :text, null: false
+    change_column :messages, :sent_at, :datetime, null: false
+    change_column :messages, :read, :boolean, null: false
+    remove_column :messages, :type, :string
+  end
+
+  def down
+    change_column :messages, :user_id, :integer, null: true
+    change_column :messages, :content, :text, null: true
+    change_column :messages, :sent_at, :datetime, null: true
+    change_column :messages, :read, :boolean, null: true
+    add_column :messages, :type, :string
+  end
+end

--- a/db/migrate/20170209121803_change_columns_to_breakdowns.rb
+++ b/db/migrate/20170209121803_change_columns_to_breakdowns.rb
@@ -1,0 +1,17 @@
+class ChangeColumnsToBreakdowns < ActiveRecord::Migration[5.0]
+  def up
+    change_column :breakdowns, :name, :string, null: false
+    change_column :breakdowns, :category_id, :integer, null: false
+    remove_column :breakdowns, :user_id
+
+    add_index :breakdowns, [:category_id, :name], unique: true
+  end
+
+  def down
+    change_column :breakdowns, :name, :string, null: true
+    change_column :breakdowns, :category_id, :integer, null: true
+    add_reference :breakdowns, :user
+
+    remove_index :breakdowns, [:category_id, :name]
+  end
+end

--- a/db/migrate/20170209123309_change_columns_to_tallies.rb
+++ b/db/migrate/20170209123309_change_columns_to_tallies.rb
@@ -1,0 +1,13 @@
+class ChangeColumnsToTallies < ActiveRecord::Migration[5.0]
+  def up
+    change_column :tallies, :user_id, :integer, null: false
+    change_column :tallies, :year, :integer, null: false
+    change_column :tallies, :list, :text, null: false
+  end
+
+  def down
+    change_column :tallies, :user_id, :integer, null: true
+    change_column :tallies, :year, :integer, null: true
+    change_column :tallies, :list, :text, null: true
+  end
+end

--- a/db/migrate/20170209123923_change_columns_to_captures.rb
+++ b/db/migrate/20170209123923_change_columns_to_captures.rb
@@ -1,0 +1,11 @@
+class ChangeColumnsToCaptures < ActiveRecord::Migration[5.0]
+  def up
+    rename_column :captures, :published_at, :published_on
+    change_column :captures, :user_id, :integer, null: false
+  end
+
+  def down
+    rename_column :captures, :published_on, :published_at
+    change_column :captures, :user_id, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170202014610) do
+ActiveRecord::Schema.define(version: 20170202022635) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "admins", force: :cascade do |t|
-    t.integer  "user_id"
+    t.integer  "user_id",    null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_admins_on_user_id", using: :btree
+    t.index ["user_id"], name: "index_admins_on_user_id", unique: true, using: :btree
   end
 
   create_table "auths", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170202022635) do
+ActiveRecord::Schema.define(version: 20170202140912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -134,7 +134,6 @@ ActiveRecord::Schema.define(version: 20170202022635) do
   create_table "notices", force: :cascade do |t|
     t.string   "title"
     t.text     "content"
-    t.string   "post_type"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.date     "post_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170209123309) do
+ActiveRecord::Schema.define(version: 20170209123923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 20170209123309) do
     t.integer  "user_id",    null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_admins_on_user_id", unique: true, using: :btree
+    t.index ["user_id"], name: "index_admins_on_user_id", using: :btree
   end
 
   create_table "auths", force: :cascade do |t|
@@ -51,13 +51,13 @@ ActiveRecord::Schema.define(version: 20170209123309) do
   end
 
   create_table "captures", force: :cascade do |t|
-    t.date     "published_at"
+    t.date     "published_on"
     t.integer  "charge"
     t.string   "category_name"
     t.string   "breakdown_name"
     t.string   "place_name"
     t.text     "memo"
-    t.integer  "user_id"
+    t.integer  "user_id",        null: false
     t.text     "tags"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
@@ -169,6 +169,8 @@ ActiveRecord::Schema.define(version: 20170209123309) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["record_id", "tag_id"], name: "index_tagged_records_on_record_id_and_tag_id", unique: true, using: :btree
+    t.index ["record_id"], name: "index_tagged_records_on_record_id", using: :btree
+    t.index ["tag_id"], name: "index_tagged_records_on_tag_id", using: :btree
   end
 
   create_table "tags", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170205162938) do
+ActiveRecord::Schema.define(version: 20170209121803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,13 +34,12 @@ ActiveRecord::Schema.define(version: 20170205162938) do
   end
 
   create_table "breakdowns", force: :cascade do |t|
-    t.string   "name"
-    t.integer  "category_id"
-    t.integer  "user_id"
+    t.string   "name",        null: false
+    t.integer  "category_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["category_id", "name"], name: "index_breakdowns_on_category_id_and_name", unique: true, using: :btree
     t.index ["category_id"], name: "index_breakdowns_on_category_id", using: :btree
-    t.index ["user_id"], name: "index_breakdowns_on_user_id", using: :btree
   end
 
   create_table "cancels", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170205152813) do
+ActiveRecord::Schema.define(version: 20170205160016) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,15 +76,15 @@ ActiveRecord::Schema.define(version: 20170205152813) do
   end
 
   create_table "categories", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",                                null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "barance_of_payments"
-    t.integer  "user_id"
-    t.integer  "position"
-    t.integer  "breakdowns_count",    default: 0, null: false
-    t.integer  "places_count",        default: 0, null: false
-    t.integer  "records_count",       default: 0, null: false
+    t.boolean  "barance_of_payments", default: false, null: false
+    t.integer  "user_id",                             null: false
+    t.integer  "position",                            null: false
+    t.integer  "breakdowns_count",    default: 0,     null: false
+    t.integer  "places_count",        default: 0,     null: false
+    t.integer  "records_count",       default: 0,     null: false
     t.index ["user_id"], name: "index_categories_on_user_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170204030018) do
+ActiveRecord::Schema.define(version: 20170204030651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,10 +89,11 @@ ActiveRecord::Schema.define(version: 20170204030018) do
   end
 
   create_table "categorize_places", force: :cascade do |t|
-    t.integer  "category_id"
-    t.integer  "place_id"
+    t.integer  "category_id", null: false
+    t.integer  "place_id",    null: false
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.index ["category_id", "place_id"], name: "index_categorize_places_on_category_id_and_place_id", unique: true, using: :btree
     t.index ["category_id"], name: "index_categorize_places_on_category_id", using: :btree
     t.index ["place_id"], name: "index_categorize_places_on_place_id", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170205160016) do
+ActiveRecord::Schema.define(version: 20170205162938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -109,14 +109,13 @@ ActiveRecord::Schema.define(version: 20170205160016) do
   end
 
   create_table "messages", force: :cascade do |t|
-    t.integer  "user_id"
+    t.integer  "user_id",                     null: false
     t.integer  "feedback_id"
-    t.text     "content"
+    t.text     "content",                     null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "type"
-    t.boolean  "read",        default: false
-    t.datetime "sent_at"
+    t.boolean  "read",        default: false, null: false
+    t.datetime "sent_at",                     null: false
     t.index ["feedback_id"], name: "index_messages_on_feedback_id", using: :btree
     t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170209121803) do
+ActiveRecord::Schema.define(version: 20170209123309) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -183,10 +183,10 @@ ActiveRecord::Schema.define(version: 20170209121803) do
   end
 
   create_table "tallies", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "year"
+    t.integer  "user_id",    null: false
+    t.integer  "year",       null: false
     t.integer  "month"
-    t.text     "list"
+    t.text     "list",       null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_tallies_on_user_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170204021228) do
+ActiveRecord::Schema.define(version: 20170204030018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,8 +44,8 @@ ActiveRecord::Schema.define(version: 20170204021228) do
   end
 
   create_table "cancels", force: :cascade do |t|
-    t.integer  "user_id"
-    t.text     "content"
+    t.integer  "user_id",    null: false
+    t.text     "content",    null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["user_id"], name: "index_cancels_on_user_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170204084638) do
+ActiveRecord::Schema.define(version: 20170205150528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,8 +23,8 @@ ActiveRecord::Schema.define(version: 20170204084638) do
   end
 
   create_table "auths", force: :cascade do |t|
-    t.integer  "user_id"
-    t.string   "provider"
+    t.integer  "user_id",     null: false
+    t.string   "provider",    null: false
     t.string   "uid"
     t.string   "screen_name"
     t.string   "name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170205150528) do
+ActiveRecord::Schema.define(version: 20170205152813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -166,12 +166,11 @@ ActiveRecord::Schema.define(version: 20170205150528) do
   end
 
   create_table "tagged_records", force: :cascade do |t|
-    t.integer  "record_id"
-    t.integer  "tag_id"
+    t.integer  "record_id",  null: false
+    t.integer  "tag_id",     null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["record_id"], name: "index_tagged_records_on_record_id", using: :btree
-    t.index ["tag_id"], name: "index_tagged_records_on_tag_id", using: :btree
+    t.index ["record_id", "tag_id"], name: "index_tagged_records_on_record_id_and_tag_id", unique: true, using: :btree
   end
 
   create_table "tags", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170202140912) do
+ActiveRecord::Schema.define(version: 20170204021228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -140,10 +140,11 @@ ActiveRecord::Schema.define(version: 20170202140912) do
   end
 
   create_table "places", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",       null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id"
+    t.integer  "user_id",    null: false
+    t.index ["user_id", "name"], name: "index_places_on_user_id_and_name", unique: true, using: :btree
     t.index ["user_id"], name: "index_places_on_user_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170204030651) do
+ActiveRecord::Schema.define(version: 20170204084638) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,15 +150,15 @@ ActiveRecord::Schema.define(version: 20170204030651) do
   end
 
   create_table "records", force: :cascade do |t|
-    t.date     "published_at"
-    t.integer  "charge"
+    t.date     "published_at", null: false
+    t.integer  "charge",       null: false
     t.integer  "breakdown_id"
     t.text     "memo"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id"
+    t.integer  "user_id",      null: false
     t.integer  "place_id"
-    t.integer  "category_id"
+    t.integer  "category_id",  null: false
     t.index ["breakdown_id"], name: "index_records_on_breakdown_id", using: :btree
     t.index ["category_id"], name: "index_records_on_category_id", using: :btree
     t.index ["place_id"], name: "index_records_on_place_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170126072522) do
+ActiveRecord::Schema.define(version: 20170202014610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -174,11 +174,13 @@ ActiveRecord::Schema.define(version: 20170126072522) do
   end
 
   create_table "tags", force: :cascade do |t|
-    t.string   "name"
-    t.string   "color_code"
-    t.integer  "user_id"
+    t.string   "name",       null: false
+    t.string   "color_code", null: false
+    t.integer  "user_id",    null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["user_id", "color_code"], name: "index_tags_on_user_id_and_color_code", unique: true, using: :btree
+    t.index ["user_id", "name"], name: "index_tags_on_user_id_and_name", unique: true, using: :btree
     t.index ["user_id"], name: "index_tags_on_user_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -148,7 +148,7 @@ ActiveRecord::Schema.define(version: 20170209123923) do
   end
 
   create_table "records", force: :cascade do |t|
-    t.date     "published_at", null: false
+    t.date     "published_on", null: false
     t.integer  "charge",       null: false
     t.integer  "breakdown_id"
     t.text     "memo"

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   factory :admin do
-    trait(:with_user) do
-      user
-    end
+    user
   end
 end

--- a/spec/factories/auths.rb
+++ b/spec/factories/auths.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   factory :auth do
-    provider ''
+    user_id { create(:user, :registered, type: 'TwitterUser').id }
+    provider 'twitter'
     sequence(:screen_name) { |n| "name#{n}" }
     sequence(:name) { |n| "名前#{n}" }
   end

--- a/spec/factories/captures.rb
+++ b/spec/factories/captures.rb
@@ -2,7 +2,7 @@
 FactoryGirl.define do
   factory :capture do
     user
-    published_at Time.zone.today
+    published_on Time.zone.today
     charge { rand(0..10_000) }
     sequence(:category_name) { |i| "カテゴリ#{i}" }
     sequence(:breakdown_name) { |i| "内訳#{i}" }

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -7,5 +7,6 @@ FactoryGirl.define do
     end
     sequence(:content) { |n| "メッセージ内容#{n}" }
     read false
+    sent_at { Time.zone.now }
   end
 end

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   factory :record do
-    published_at Time.zone.today
+    published_on Time.zone.today
     user
     category
     breakdown

--- a/spec/factories/tagged_records.rb
+++ b/spec/factories/tagged_records.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :tagged_record do
+    record
+    tag
+  end
+end

--- a/spec/factories/tallies.rb
+++ b/spec/factories/tallies.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
     user
     year [*2010..2016].sample
     month [*1..12].sample
+    list '[]'
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,7 +28,7 @@ FactoryGirl.define do
     end
 
     trait :admin_user do
-      admin
+      admin { build(:admin, user_id: id) }
     end
   end
 end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Admin, type: :model do
   it { is_expected.to belong_to(:user) }
 
   describe 'バリデーション' do
+    let(:user) { create(:user) }
+    subject { create(:admin, user: user) }
+
     it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_uniqueness_of(:user_id) }
   end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -3,4 +3,9 @@ require 'rails_helper'
 
 RSpec.describe Admin, type: :model do
   it { is_expected.to belong_to(:user) }
+
+  describe 'バリデーション' do
+    it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to validate_uniqueness_of(:user_id) }
+  end
 end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe Admin, type: :model do
   it { is_expected.to belong_to(:user) }
 
   describe 'バリデーション' do
-    let(:user) { create(:user) }
-    subject { create(:admin, user: user) }
+    subject { create(:admin, user: create(:email_user, :registered)) }
 
     it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_uniqueness_of(:user_id) }

--- a/spec/models/auth_spec.rb
+++ b/spec/models/auth_spec.rb
@@ -3,4 +3,18 @@ require 'rails_helper'
 
 RSpec.describe Auth, type: :model do
   it { is_expected.to belong_to(:twitter_user) }
+  it { is_expected.to belong_to(:facebook_user) }
+
+  describe 'バリデーション' do
+    let(:user) { create(:twitter_user, :registered) }
+    subject { create(:auth, provider: 'twitter', user_id: user.id) }
+
+    it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to validate_presence_of(:provider) }
+
+    it do
+      is_expected.to validate_inclusion_of(:provider)
+        .in_array(%w(twitter facebook))
+    end
+  end
 end

--- a/spec/models/breakdown_spec.rb
+++ b/spec/models/breakdown_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe Breakdown, type: :model do
   it { is_expected.to have_many(:records) }
   it { is_expected.to have_many(:captures) }
 
-  it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_length_of(:name).is_at_most(100) }
+  describe 'validation' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_most(100) }
+    it { is_expected.to validate_presence_of(:category_id) }
+  end
 end

--- a/spec/models/capture_spec.rb
+++ b/spec/models/capture_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Capture, type: :model do
   it { is_expected.to belong_to(:place) }
 
   describe 'バリデーション' do
-    it { is_expected.to validate_presence_of(:published_at) }
+    it { is_expected.to validate_presence_of(:published_on) }
     it { is_expected.to validate_presence_of(:category_name) }
     it { is_expected.to validate_length_of(:category_name).is_at_most(100) }
     it { is_expected.to validate_length_of(:breakdown_name).is_at_most(100) }

--- a/spec/models/categorize_place_spec.rb
+++ b/spec/models/categorize_place_spec.rb
@@ -5,7 +5,15 @@ RSpec.describe CategorizePlace, type: :model do
   it { is_expected.to belong_to(:category) }
   it { is_expected.to belong_to(:place) }
 
-  it do
-    is_expected.to validate_uniqueness_of(:category_id).scoped_to(:place_id)
+  describe 'バリデーション' do
+    let(:category) { create(:category) }
+    let(:place) { create(:place) }
+    subject { create(:categorize_place, category: category, place: place) }
+
+    it { is_expected.to validate_presence_of(:category_id) }
+    it { is_expected.to validate_presence_of(:place_id) }
+    it do
+      is_expected.to validate_uniqueness_of(:category_id).scoped_to(:place_id)
+    end
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -2,7 +2,8 @@
 require 'rails_helper'
 
 RSpec.describe Category, type: :model do
-  let!(:category) { create(:category, user: create(:email_user, :registered)) }
+  let(:user) { create(:email_user, :registered) }
+  let!(:category) { create(:category, user: user, barance_of_payments: true) }
 
   it { is_expected.to belong_to(:user) }
   it { is_expected.to have_many(:breakdowns) }
@@ -14,6 +15,8 @@ RSpec.describe Category, type: :model do
   describe 'validation' do
     subject { category }
     it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to validate_presence_of(:position) }
     it { is_expected.to validate_length_of(:name).is_at_most(100) }
   end
 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Category, type: :model do
     subject { category }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:user_id) }
-    it { is_expected.to validate_presence_of(:position) }
     it { is_expected.to validate_length_of(:name).is_at_most(100) }
   end
 

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -4,25 +4,20 @@ require 'rails_helper'
 RSpec.describe Feedback, type: :model do
   it { is_expected.to belong_to(:user) }
   it { is_expected.to have_many(:messages) }
-  it { is_expected.to validate_presence_of(:content) }
-  it { is_expected.to validate_length_of(:content).is_at_most(10_000) }
-  it { is_expected.to validate_length_of(:email).is_at_most(100) }
 
-  context '内容が空の場合' do
-    let!(:user) { create(:user, :registered) }
+  describe 'バリデーション' do
+    it { is_expected.to validate_presence_of(:content) }
+    it { is_expected.to validate_length_of(:content).is_at_most(10_000) }
+    it { is_expected.to validate_length_of(:email).is_at_most(100) }
 
-    it 'エラーが発生すること' do
-      feedback = Feedback.new(user_id: user.id, content: '')
-      feedback.valid?
-      expect(feedback.errors.full_messages).to eq ['内容を入力してください']
+    context 'when email is null' do
+      before { allow(subject).to receive(:email).and_return(nil) }
+      it { is_expected.not_to validate_presence_of(:email) }
     end
-  end
 
-  context 'emailが空の場合' do
-    it 'エラーが発生すること' do
-      feedback = Feedback.new(email: '', content: 'Content')
-      feedback.valid?
-      expect(feedback.errors.full_messages).to eq ['メールアドレスを入力してください']
+    context 'when email is blank' do
+      before { allow(subject).to receive(:email).and_return('') }
+      it { is_expected.to validate_presence_of(:email) }
     end
   end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Message, type: :model do
   it { is_expected.to belong_to(:user) }
   it { is_expected.to belong_to(:feedback) }
 
-  it { is_expected.to validate_length_of(:content).is_at_most(10_000) }
-  it { is_expected.to validate_presence_of(:user) }
+  describe 'バリデーション' do
+    it { is_expected.to validate_presence_of(:content) }
+    it { is_expected.to validate_length_of(:content).is_at_most(10_000) }
+    it { is_expected.to validate_presence_of(:user) }
+  end
 end

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -2,7 +2,19 @@
 require 'rails_helper'
 
 RSpec.describe Notice, type: :model do
-  it { is_expected.to validate_presence_of(:title) }
-  it { is_expected.to validate_length_of(:title).is_at_most(100) }
-  it { is_expected.to validate_length_of(:content).is_at_most(10_000) }
+  describe 'バリデーション' do
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_length_of(:title).is_at_most(100) }
+    it { is_expected.to validate_length_of(:content).is_at_most(10_000) }
+  end
+
+  describe '#published' do
+    let!(:publish_notice) { create(:notice, post_at: Time.zone.today) }
+    let!(:unpublish_notice) { create(:notice, post_at: Time.zone.tomorrow) }
+    subject { Notice.all.published }
+
+    it '公開日が今日より前の投稿のみ取得できる' do
+      expect(subject).to eq [publish_notice]
+    end
+  end
 end

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -2,14 +2,19 @@
 require 'rails_helper'
 
 RSpec.describe Place, type: :model do
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to have_many(:categorize_places) }
+  it { is_expected.to have_many(:categories).through(:categorize_places) }
+  it { is_expected.to have_many(:records) }
+  it { is_expected.to have_many(:captures) }
+
   describe 'validation' do
-    subject { create(:place, user: create(:email_user, :registered)) }
-    it { is_expected.to belong_to(:user) }
-    it { is_expected.to have_many(:categorize_places) }
-    it { is_expected.to have_many(:categories).through(:categorize_places) }
-    it { is_expected.to have_many(:records) }
-    it { is_expected.to have_many(:captures) }
+    let(:user) { create(:email_user, :registered) }
+    subject { create(:place, user: user, name: 'dummy_name') }
+
+    it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name).scoped_to(:user_id) }
     it { is_expected.to validate_length_of(:name).is_at_most(100) }
   end
 end

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Record, type: :model do
   describe 'validation' do
     subject { create(:record, user: create(:email_user, :registered)) }
 
-    it { is_expected.to validate_presence_of(:published_at) }
+    it { is_expected.to validate_presence_of(:published_on) }
     it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_presence_of(:category) }
     it { is_expected.to validate_presence_of(:charge) }

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -11,9 +11,12 @@ RSpec.describe Record, type: :model do
 
   describe 'validation' do
     subject { create(:record, user: create(:email_user, :registered)) }
+
     it { is_expected.to validate_presence_of(:published_at) }
-    it { is_expected.to validate_presence_of(:charge) }
+    it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_presence_of(:category) }
+    it { is_expected.to validate_presence_of(:charge) }
+    it { is_expected.to validate_numericality_of(:charge).only_integer }
     it { is_expected.to validate_length_of(:memo).is_at_most(10_000) }
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Tag, type: :model do
   it { is_expected.to have_many(:records).through(:tagged_records) }
 
   describe 'バリデーション' do
+    subject { create(:tag, name: 'dummy_name', color_code: '#ffffff') }
+
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name).scoped_to(:user_id) }
     it do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Tag, type: :model do
   describe 'バリデーション' do
     subject { create(:tag, name: 'dummy_name', color_code: '#ffffff') }
 
+    it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name).scoped_to(:user_id) }
     it do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -7,6 +7,18 @@ RSpec.describe Tag, type: :model do
   it { is_expected.to have_many(:records).through(:tagged_records) }
 
   describe 'バリデーション' do
+    it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name).scoped_to(:user_id) }
+    it { is_expected.to validate_uniqueness_of(:color_code).scoped_to(:user_id) }
+  end
+
+  describe '#set_color_code' do
+    subject { build(:tag, color_code: nil) }
+
+    it '保存時にカラーコードが設定されること' do
+      subject.save!
+      expect(subject.color_code).to be_a String
+      expect(subject.color_code).to match /\A\#\w{6}\Z/
+    end
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Tag, type: :model do
   describe 'バリデーション' do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name).scoped_to(:user_id) }
-    it { is_expected.to validate_uniqueness_of(:color_code).scoped_to(:user_id) }
+    it do
+      is_expected.to validate_uniqueness_of(:color_code).scoped_to(:user_id)
+    end
   end
 
   describe '#set_color_code' do
@@ -18,7 +20,7 @@ RSpec.describe Tag, type: :model do
     it '保存時にカラーコードが設定されること' do
       subject.save!
       expect(subject.color_code).to be_a String
-      expect(subject.color_code).to match /\A\#\w{6}\Z/
+      expect(subject.color_code).to match(/\A\#\w{6}\Z/)
     end
   end
 end

--- a/spec/models/tagged_record_spec.rb
+++ b/spec/models/tagged_record_spec.rb
@@ -4,4 +4,17 @@ require 'rails_helper'
 RSpec.describe TaggedRecord, type: :model do
   it { is_expected.to belong_to(:record) }
   it { is_expected.to belong_to(:tag) }
+
+  describe 'バリデーション' do
+    let(:record) { create(:record) }
+    let(:tag) { create(:tag) }
+
+    subject { create(:tagged_record, record: record, tag: tag) }
+
+    it { is_expected.to validate_presence_of(:record_id) }
+    it { is_expected.to validate_presence_of(:tag_id) }
+    it do
+      is_expected.to validate_uniqueness_of(:record_id).scoped_to(:tag_id)
+    end
+  end
 end

--- a/spec/models/tally_spec.rb
+++ b/spec/models/tally_spec.rb
@@ -3,4 +3,9 @@ require 'rails_helper'
 
 RSpec.describe Tally, type: :model do
   it { is_expected.to belong_to(:user) }
+
+  describe 'validation' do
+    it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to validate_presence_of(:year) }
+  end
 end

--- a/spec/requests/admin/messages_spec.rb
+++ b/spec/requests/admin/messages_spec.rb
@@ -25,6 +25,12 @@ describe 'GET /admin/messages?offset=offset', autodoc: true do
   end
 
   context '管理ユーザーとしてログインしている場合' do
+    let!(:sent_at) { Time.zone.now }
+
+    before do
+      Timecop.freeze(sent_at)
+    end
+
     context '1ページ以内のメッセージ数の場合' do
       it '200が返り、メッセージ一覧が返ってくること' do
         get '/admin/messages/', params: '', headers: login_headers(admin_user)
@@ -35,7 +41,7 @@ describe 'GET /admin/messages?offset=offset', autodoc: true do
             {
               id: message2.id,
               read: false,
-              sent_at: '',
+              sent_at: I18n.l(sent_at),
               user_name: message2.user.decorate.screen_name,
               feedback_content: message2.feedback.try(:content),
               content: message2.content,
@@ -44,7 +50,7 @@ describe 'GET /admin/messages?offset=offset', autodoc: true do
             {
               id: message1.id,
               read: false,
-              sent_at: '',
+              sent_at: I18n.l(sent_at),
               user_name: message1.user.decorate.screen_name,
               feedback_content: message1.feedback.try(:content),
               content: message1.content,
@@ -68,7 +74,7 @@ describe 'GET /admin/messages?offset=offset', autodoc: true do
             {
               id: message1.id,
               read: false,
-              sent_at: '',
+              sent_at: I18n.l(sent_at),
               user_name: message1.user.decorate.screen_name,
               feedback_content: message1.feedback.try(:content),
               content: message1.content,
@@ -79,6 +85,10 @@ describe 'GET /admin/messages?offset=offset', autodoc: true do
         }
         expect(response.body).to be_json_as(json)
       end
+    end
+
+    after do
+      Timecop.return
     end
   end
 end

--- a/spec/requests/captures_spec.rb
+++ b/spec/requests/captures_spec.rb
@@ -44,7 +44,7 @@ describe 'GET /captures', autodoc: true do
           {
             id: captures[5].id,
             created_at: I18n.l(captures[5].created_at),
-            published_at: '2016-08-01',
+            published_on: '2016-08-01',
             category_name: '水道光熱費',
             category_payments: category.barance_of_payments,
             category_id: category.id,
@@ -60,7 +60,7 @@ describe 'GET /captures', autodoc: true do
           {
             id: captures[4].id,
             created_at: I18n.l(captures[4].created_at),
-            published_at: nil,
+            published_on: nil,
             category_name: 'カテゴリ' * 30,
             category_payments: nil,
             category_id: nil,
@@ -76,7 +76,7 @@ describe 'GET /captures', autodoc: true do
           {
             id: captures[3].id,
             created_at: I18n.l(captures[3].created_at),
-            published_at: '2016-08-06',
+            published_on: '2016-08-06',
             category_name: '',
             category_payments: nil,
             category_id: nil,
@@ -92,7 +92,7 @@ describe 'GET /captures', autodoc: true do
           {
             id: captures[2].id,
             created_at: I18n.l(captures[2].created_at),
-            published_at: '2016-08-03',
+            published_on: '2016-08-03',
             category_name: '飲食費',
             category_payments: nil,
             category_id: nil,
@@ -108,7 +108,7 @@ describe 'GET /captures', autodoc: true do
           {
             id: captures[1].id,
             created_at: I18n.l(captures[1].created_at),
-            published_at: '2016-08-03',
+            published_on: '2016-08-03',
             category_name: '消耗品費',
             category_payments: nil,
             category_id: nil,
@@ -124,7 +124,7 @@ describe 'GET /captures', autodoc: true do
           {
             id: captures[0].id,
             created_at: I18n.l(captures[0].created_at),
-            published_at: '2016-08-01',
+            published_on: '2016-08-01',
             category_name: '水道光熱費',
             category_payments: category.barance_of_payments,
             category_id: category.id,
@@ -167,7 +167,7 @@ describe 'GET /capture/:id', autodoc: true do
       json = {
         id: capture.id,
         created_at: capture.created_at.strftime('%Y/%m/%d %H:%M:%S'),
-        published_at: capture.published_at.strftime('%Y-%m-%d'),
+        published_on: capture.published_on.strftime('%Y-%m-%d'),
         category_name: capture.category_name,
         category_payments: capture.category.try(:barance_of_payments),
         category_id: capture.category_id,
@@ -216,7 +216,7 @@ describe 'POST /captures/import', autodoc: true do
 
       expect(user.captures.count).to eq 4
       capture1 = user.captures.first
-      expect(capture1.published_at).to eq '2016-08-01'.to_date
+      expect(capture1.published_on).to eq '2016-08-01'.to_date
       expect(capture1.category_name).to eq '水道光熱費'
       expect(capture1.breakdown_name).to eq '電気代'
       expect(capture1.place_name).to eq '東京電力'
@@ -232,7 +232,7 @@ describe 'PATCH /captures/:id', autodoc: true do
   let!(:capture) { create(:capture, user: user) }
   let!(:params) do
     {
-      published_at: '2016-08-08',
+      published_on: '2016-08-08',
       category_name: 'カテゴリ名',
       breakdown_name: '内訳',
       place_name: '場所',
@@ -257,7 +257,7 @@ describe 'PATCH /captures/:id', autodoc: true do
       expect(response.status).to eq 200
 
       capture.reload
-      expect(capture.published_at).to eq '2016-08-08'.to_date
+      expect(capture.published_on).to eq '2016-08-08'.to_date
       expect(capture.category_name).to eq 'カテゴリ名'
       expect(capture.breakdown_name).to eq '内訳'
       expect(capture.place_name).to eq '場所'

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -34,10 +34,10 @@ describe 'GET /dashboard', autodoc: true do
 
     context 'データが先月分と今月分あり、今月分表示する場合' do
       let!(:last_month_record1) do
-        create(:record, published_at: 1.month.ago, user: user)
+        create(:record, published_on: 1.month.ago, user: user)
       end
       let!(:last_month_record2) do
-        create(:record, published_at: 1.month.ago, user: user)
+        create(:record, published_on: 1.month.ago, user: user)
       end
       let!(:today_record1) { create(:record, user: user) }
       let!(:today_record2) { create(:record, user: user) }

--- a/spec/requests/mypage_spec.rb
+++ b/spec/requests/mypage_spec.rb
@@ -21,7 +21,7 @@ describe 'GET /mypage', autodoc: true do
     let!(:record1) { create(:record, user: user) }
     let!(:record2) { create(:record, user: user) }
     let!(:record3) do
-      create(:record, user: user, published_at: 1.month.ago)
+      create(:record, user: user, published_on: 1.month.ago)
     end
 
     it '200とお知らせ情報、メッセージ情報を返すこと' do
@@ -60,7 +60,7 @@ describe 'GET /mypage', autodoc: true do
         records: [
           {
             id: record3.id,
-            published_at: record3.published_at.strftime('%Y-%m-%d'),
+            published_on: record3.published_on.strftime('%Y-%m-%d'),
             payments: record3.category.barance_of_payments,
             charge: record3.charge,
             category_name: record3.category.name,
@@ -70,7 +70,7 @@ describe 'GET /mypage', autodoc: true do
           },
           {
             id: record2.id,
-            published_at: record2.published_at.strftime('%Y-%m-%d'),
+            published_on: record2.published_on.strftime('%Y-%m-%d'),
             payments: record2.category.barance_of_payments,
             charge: record2.charge,
             category_name: record2.category.name,
@@ -80,7 +80,7 @@ describe 'GET /mypage', autodoc: true do
           },
           {
             id: record1.id,
-            published_at: record1.published_at.strftime('%Y-%m-%d'),
+            published_on: record1.published_on.strftime('%Y-%m-%d'),
             payments: record1.category.barance_of_payments,
             charge: record1.charge,
             category_name: record1.category.name,

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -446,7 +446,7 @@ describe 'POST /records/import', autodoc: true do
           record_id: record.id
         }
         expect(response.body).to be_json_as(json)
-        expect(record.published_at).to eq capture.published_at
+        expect(record.published_at).to eq capture.published_on
         expect(record.charge).to eq capture.charge
         expect(record.category.name).to eq capture.category_name
         expect(record.breakdown.try(:name)).to eq capture.breakdown_name
@@ -468,7 +468,7 @@ describe 'POST /records/import', autodoc: true do
         expect(response.status).to eq 200
 
         record = user.records.last
-        expect(record.published_at).to eq capture.published_at
+        expect(record.published_at).to eq capture.published_on
         expect(record.charge).to eq capture.charge
         expect(record.category.name).to eq capture.category_name
         expect(record.breakdown.try(:name)).to eq capture.breakdown_name

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -14,7 +14,7 @@ describe 'GET /records', autodoc: true do
     let!(:record1) { create(:record, user: user) }
     let!(:record2) { create(:record, user: user) }
     let!(:record3) do
-      create(:record, user: user, published_at: 1.month.ago)
+      create(:record, user: user, published_on: 1.month.ago)
     end
     let!(:tag) { create(:tag, user: user) }
 
@@ -32,7 +32,7 @@ describe 'GET /records', autodoc: true do
           records: [
             {
               id: record2.id,
-              published_at: record2.published_at.strftime('%Y-%m-%d'),
+              published_on: record2.published_on.strftime('%Y-%m-%d'),
               payments: record2.category.barance_of_payments,
               charge: record2.charge,
               category_id: record2.category.id,
@@ -48,7 +48,7 @@ describe 'GET /records', autodoc: true do
             },
             {
               id: record1.id,
-              published_at: record1.published_at.strftime('%Y-%m-%d'),
+              published_on: record1.published_on.strftime('%Y-%m-%d'),
               payments: record1.category.barance_of_payments,
               charge: record1.charge,
               category_id: record1.category.id,
@@ -84,7 +84,7 @@ describe 'GET /records', autodoc: true do
           records: [
             {
               id: record2.id,
-              published_at: record2.published_at.strftime('%Y-%m-%d'),
+              published_on: record2.published_on.strftime('%Y-%m-%d'),
               payments: record2.category.barance_of_payments,
               charge: record2.charge,
               category_id: record2.category.id,
@@ -98,7 +98,7 @@ describe 'GET /records', autodoc: true do
             },
             {
               id: record1.id,
-              published_at: record1.published_at.strftime('%Y-%m-%d'),
+              published_on: record1.published_on.strftime('%Y-%m-%d'),
               payments: record1.category.barance_of_payments,
               charge: record1.charge,
               category_id: record1.category.id,
@@ -134,7 +134,7 @@ describe 'GET /records', autodoc: true do
           records: [
             {
               id: record3.id,
-              published_at: record3.published_at.strftime('%Y-%m-%d'),
+              published_on: record3.published_on.strftime('%Y-%m-%d'),
               payments: record3.category.barance_of_payments,
               charge: record3.charge,
               category_id: record3.category.id,
@@ -172,7 +172,7 @@ describe 'GET /records', autodoc: true do
               records: [
                 {
                   id: record2.id,
-                  published_at: record2.published_at.strftime('%Y-%m-%d'),
+                  published_on: record2.published_on.strftime('%Y-%m-%d'),
                   payments: record2.category.barance_of_payments,
                   charge: record2.charge,
                   category_id: record2.category.id,
@@ -186,7 +186,7 @@ describe 'GET /records', autodoc: true do
                 },
                 {
                   id: record1.id,
-                  published_at: record1.published_at.strftime('%Y-%m-%d'),
+                  published_on: record1.published_on.strftime('%Y-%m-%d'),
                   payments: record1.category.barance_of_payments,
                   charge: record1.charge,
                   category_id: record1.category.id,
@@ -212,7 +212,7 @@ describe 'GET /records', autodoc: true do
               records: [
                 {
                   id: record2.id,
-                  published_at: record2.published_at.strftime('%Y-%m-%d'),
+                  published_on: record2.published_on.strftime('%Y-%m-%d'),
                   payments: record2.category.barance_of_payments,
                   charge: record2.charge,
                   category_id: record2.category.id,
@@ -226,7 +226,7 @@ describe 'GET /records', autodoc: true do
                 },
                 {
                   id: record1.id,
-                  published_at: record1.published_at.strftime('%Y-%m-%d'),
+                  published_on: record1.published_on.strftime('%Y-%m-%d'),
                   payments: record1.category.barance_of_payments,
                   charge: record1.charge,
                   category_id: record1.category.id,
@@ -240,7 +240,7 @@ describe 'GET /records', autodoc: true do
                 },
                 {
                   id: record3.id,
-                  published_at: record3.published_at.strftime('%Y-%m-%d'),
+                  published_on: record3.published_on.strftime('%Y-%m-%d'),
                   payments: record3.category.barance_of_payments,
                   charge: record3.charge,
                   category_id: record3.category.id,
@@ -286,7 +286,7 @@ describe 'GET /records/:id', autodoc: true do
 
       json = {
         id: record.id,
-        published_at: record.published_at.strftime('%Y-%m-%d'),
+        published_on: record.published_on.strftime('%Y-%m-%d'),
         payments: record.category.barance_of_payments,
         charge: record.charge,
         category_name: record.category.name,
@@ -372,7 +372,7 @@ describe 'POST /records', autodoc: true do
   let!(:charge) { '8000' }
   let!(:params) do
     {
-      charge: charge, published_at: Time.zone.today,
+      charge: charge, published_on: Time.zone.today,
       category_id: category.id, breakdown_id: breakdown.id, place_id: place.id,
       tags: [{ id: tag1.id, name: '既存タグ', color_code: '#ffffff' },
              { id: tag2.id, name: '既存タグ2' },
@@ -446,7 +446,7 @@ describe 'POST /records/import', autodoc: true do
           record_id: record.id
         }
         expect(response.body).to be_json_as(json)
-        expect(record.published_at).to eq capture.published_on
+        expect(record.published_on).to eq capture.published_on
         expect(record.charge).to eq capture.charge
         expect(record.category.name).to eq capture.category_name
         expect(record.breakdown.try(:name)).to eq capture.breakdown_name
@@ -468,7 +468,7 @@ describe 'POST /records/import', autodoc: true do
         expect(response.status).to eq 200
 
         record = user.records.last
-        expect(record.published_at).to eq capture.published_on
+        expect(record.published_on).to eq capture.published_on
         expect(record.charge).to eq capture.charge
         expect(record.category.name).to eq capture.category_name
         expect(record.breakdown.try(:name)).to eq capture.breakdown_name
@@ -538,7 +538,7 @@ describe 'GET /records/:id/edit', autodoc: true do
         },
         record: {
           id: record.id,
-          published_at: record.published_at.strftime('%Y-%m-%d'),
+          published_on: record.published_on.strftime('%Y-%m-%d'),
           payments: record.category.barance_of_payments,
           charge: record.charge,
           category_name: record.category.name,
@@ -559,7 +559,7 @@ describe 'PATCH /records/:id', autodoc: true do
   let!(:charge) { '900' }
   let!(:params) do
     {
-      charge: charge, published_at: Time.zone.today,
+      charge: charge, published_on: Time.zone.today,
       category: Category.last, breakdown: Breakdown.last, place: Place.last
     }
   end

--- a/src/app/user/import/import_history.jade
+++ b/src/app/user/import/import_history.jade
@@ -39,7 +39,7 @@
          ng-mouseover='import_history.selectLine($index)'
          ng-class="import_history.updateAnimate")
         td.line-color(ng-class="{ 'line-color-red': import_history.selectLineNumber == $index}")
-        td {{ capture.published_at | date:'yyyy-MM-dd' }}
+        td {{ capture.published_on | date:'yyyy-MM-dd' }}
         td
           payments-glyphicon-directive(payments='capture.category_payments')
         td

--- a/src/app/user/import/modals/capture.jade
+++ b/src/app/user/import/modals/capture.jade
@@ -24,14 +24,14 @@ form.form-horizontal(novalidate=true name='form' ng-submit='modal.submit()')
         span {{ modal.capture.created_at }}
     // 日付
     .form-group
-      label.control-label.col-sm-3(for='published_at')
+      label.control-label.col-sm-3(for='published_on')
         span(translate='COLUMNS.PUBLISHED_AT')
         span.red *
       .modal-label.col-sm-9(ng-show='!modal.editing')
-        span {{ modal.capture.published_at }}
+        span {{ modal.capture.published_on }}
       .col-sm-9(ng-show='modal.editing')
-        input.btn.btn-default(type='date' name='published_at' ng-model='modal.published_at' datepicker-popup=true required='true')
-        span.errors(ng-messages='form.published_at.$error' ng-show='form.published_at.$error')
+        input.btn.btn-default(type='date' name='published_on' ng-model='modal.published_on' datepicker-popup=true required='true')
+        span.errors(ng-messages='form.published_on.$error' ng-show='form.published_on.$error')
           div(ng-message='required')
             span.glyphicon.glyphicon-alert#left-icon
             span(translate='ERRORS.REQUIRED.PUBLISHED_AT')

--- a/src/app/user/import/modals/edit_capture.controller.coffee
+++ b/src/app/user/import/modals/edit_capture.controller.coffee
@@ -3,7 +3,7 @@ EditCaptureController = (IndexService, ImportFactory, capture, $uibModalInstance
   vm = this
   vm.capture = capture.capture
   vm.user_currency = capture.user_currency
-  vm.published_at = new Date(vm.capture.published_at)
+  vm.published_on = new Date(vm.capture.published_on)
   vm.category_name = vm.capture.category_name
   vm.category = { name: vm.category_name, payments: false }
   vm.breakdown_name = vm.capture.breakdown_name
@@ -19,7 +19,7 @@ EditCaptureController = (IndexService, ImportFactory, capture, $uibModalInstance
   setCapture = () ->
     ImportFactory.getCapture(capture_id).then (res) ->
       vm.capture = res
-      vm.published_at = new Date(vm.capture.published_at)
+      vm.published_on = new Date(vm.capture.published_on)
       vm.category_name = vm.capture.category_name
       vm.breakdown_name = vm.capture.breakdown_name
       vm.place_name = vm.capture.place_name
@@ -65,7 +65,7 @@ EditCaptureController = (IndexService, ImportFactory, capture, $uibModalInstance
   vm.submit = () ->
     IndexService.sending = true
     params =
-      published_at: String(vm.published_at)
+      published_on: String(vm.published_on)
       category_name: vm.category_name
       breakdown_name: vm.breakdown_name
       place_name: vm.place_name


### PR DESCRIPTION
## 対応内容

以下テーブルについてバリデーションを追加し、それに伴いテストの修正も行いました。
- tags
- places
- notices
- admins
- feedbacks
- cancels
- categorize_places
- records
- auths
- tagged_records
- messages
- tallies
- breakdowns
- captures
- records

## 対応理由

足りないバリデーションがあったため
