### PR TITLE
データを登録できなくなっていたバグを修正

### DIFF
--- a/src/app/components/records/modals/record.jade
+++ b/src/app/components/records/modals/record.jade
@@ -17,14 +17,14 @@ form.form-horizontal(novalidate=true name='editRecordForm' ng-submit='edit_recor
     loading-directive(target='modal')
     // 日付
     .form-group
-      label.control-label.col-sm-2(for='published_at')
+      label.control-label.col-sm-2(for='published_on')
         span(translate='COLUMNS.PUBLISHED_AT')
         span.red *
       .modal-label.col-sm-10(ng-show='!edit_record.editing')
-        span {{ edit_record.record.published_at }}
+        span {{ edit_record.record.published_on }}
       .col-sm-10(ng-show='edit_record.editing')
-        input.btn.btn-default(type='date' name='published_at' ng-model='edit_record.published_at' datepicker-popup=true required='true')
-        span.errors(ng-messages='editRecordForm.published_at.$error' ng-show='editRecordForm.$submitted && editRecordForm.published_at.$error')
+        input.btn.btn-default(type='date' name='published_on' ng-model='edit_record.published_on' datepicker-popup=true required='true')
+        span.errors(ng-messages='editRecordForm.published_on.$error' ng-show='editRecordForm.$submitted && editRecordForm.published_on.$error')
           div(ng-message='required')
             span.glyphicon.glyphicon-alert#left-icon
             span(translate='ERRORS.REQUIRED.PUBLISHED_AT')

--- a/src/app/records/list/list.jade
+++ b/src/app/records/list/list.jade
@@ -54,7 +54,7 @@ form.form.form-inline
     loading-directive
     table.table(ng-show='list.records')
       tr(ng-repeat='record in list.records')
-        td {{ record.published_at }}
+        td {{ record.published_on }}
         td
           label.label.label-warning(ng-click='list.clickCategory(record.category_id)') {{ record.category_name }}
         td

--- a/src/app/records/modals/edit_record.controller.coffee
+++ b/src/app/records/modals/edit_record.controller.coffee
@@ -4,7 +4,7 @@ EditRecordController = (IndexService, RecordsFactory, record_id, $uibModalInstan
   vm.editing = false
 
   setData = () ->
-    vm.published_at = new Date(vm.record.published_at)
+    vm.published_on = new Date(vm.record.published_on)
     vm.categories.forEach (c, i) ->
       if c.name == vm.record.category_name
         vm.category_id = c.id
@@ -45,12 +45,12 @@ EditRecordController = (IndexService, RecordsFactory, record_id, $uibModalInstan
     $uibModalInstance.dismiss()
 
   vm.setToday = () ->
-    vm.published_at = new Date()
+    vm.published_on = new Date()
 
   vm.submit = () ->
     IndexService.sending = true
     params =
-      published_at: String(vm.published_at)
+      published_on: String(vm.published_on)
       category_id: vm.category_id
       breakdown_id: vm.breakdown_id
       place_id: vm.place_id

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -30,12 +30,12 @@
       form.form-horizontal(novalidate=true name='newRecordForm' ng-submit='new_record.submit()')
         // 日付
         .form-group
-          label.control-label.col-sm-2(for='published_at')
+          label.control-label.col-sm-2(for='published_on')
             span(translate='COLUMNS.PUBLISHED_AT')
             span.red *
           .col-sm-10
-            input.btn.btn-default(type='date' name='published_at' ng-model='new_record.published_at' datepicker-popup=true required='true' ng-change='new_record.changeDate()')
-            span.errors(ng-messages='newRecordForm.published_at.$error' ng-show='newRecordForm.$submitted && newRecordForm.published_at.$error')
+            input.btn.btn-default(type='date' name='published_on' ng-model='new_record.published_on' datepicker-popup=true required='true' ng-change='new_record.changeDate()')
+            span.errors(ng-messages='newRecordForm.published_on.$error' ng-show='newRecordForm.$submitted && newRecordForm.published_on.$error')
               div(ng-message='required')
                 span.glyphicon.glyphicon-alert#left-icon
                 span(translate='ERRORS.REQUIRED.PUBLISHED_AT')
@@ -156,7 +156,7 @@
           .btn.btn-info.btn-xs.pull-right(ng-click='new_record.getTomorrowRecords()')
             .glyphicon.glyphicon-chevron-right
           .text-center
-            | {{ new_record.records_published_at | date:'yyyy年MM月dd日' }}
+            | {{ new_record.records_published_on | date:'yyyy年MM月dd日' }}
             span(translate='LABELS.ADD_20')
           loading-directive(target='records')
           table.table.table-condensed

--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -2,8 +2,8 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $uibModal, 
   'ngInject'
   vm = this
 
-  vm.published_at = new Date()
-  vm.records_published_at = new Date()
+  vm.published_on = new Date()
+  vm.records_published_on = new Date()
   vm.settings = false
 
   IndexService.loading = true
@@ -31,14 +31,14 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $uibModal, 
       month: Number($filter('date')(target_date, 'MM'))
       day: Number($filter('date')(target_date, 'dd'))
     RecordsFactory.getRecords(params).then((res) ->
-      vm.records_published_at = target_date
+      vm.records_published_on = target_date
       vm.day_records = res.records
       IndexService.records_loading = false
     ).catch (res) ->
       IndexService.records_loading = false
     return
  
-  getRecordsWithDate(vm.published_at)
+  getRecordsWithDate(vm.published_on)
 
   # 「登録」ボタン
   vm.submit = () ->
@@ -47,7 +47,7 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $uibModal, 
     if category
       vm.category_id = category.id
     params =
-      published_at: String(vm.published_at)
+      published_on: String(vm.published_on)
       category_id: vm.category_id
       breakdown_id: vm.breakdown_id
       place_id: vm.place_id
@@ -64,19 +64,19 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $uibModal, 
       vm.tags = ''
       IndexService.sending = false
       $scope.newRecordForm.$setPristine()
-      getRecordsWithDate(vm.published_at)
+      getRecordsWithDate(vm.published_on)
     ).catch (res) ->
       IndexService.sending = false
 
   # 「<」ボタン
   vm.getYesterdayRecords = () ->
-    vm.records_published_at.setDate(vm.records_published_at.getDate() - 1)
-    getRecordsWithDate(vm.records_published_at)
+    vm.records_published_on.setDate(vm.records_published_on.getDate() - 1)
+    getRecordsWithDate(vm.records_published_on)
 
   # 「>」ボタン
   vm.getTomorrowRecords = () ->
-    vm.records_published_at.setDate(vm.records_published_at.getDate() + 1)
-    getRecordsWithDate(vm.records_published_at)
+    vm.records_published_on.setDate(vm.records_published_on.getDate() + 1)
+    getRecordsWithDate(vm.records_published_on)
 
   # 「カテゴリ」選択
   vm.selectCategory = () ->
@@ -101,7 +101,7 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $uibModal, 
 
   # 日付変更
   vm.changeDate = () ->
-    getRecordsWithDate(vm.published_at)
+    getRecordsWithDate(vm.published_on)
 
   # コピーアイコン
   vm.copyRecord = (record) ->
@@ -126,8 +126,8 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $uibModal, 
 
   # 「今日」ボタン
   vm.setToday = () ->
-    vm.published_at = new Date()
-    getRecordsWithDate(vm.published_at)
+    vm.published_on = new Date()
+    getRecordsWithDate(vm.published_on)
 
   SettingsFactory.getTags().then (res) ->
     vm.list_tags = res.tags
@@ -195,7 +195,7 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $uibModal, 
       backdrop: 'static'
     )
     modalInstance.result.then () ->
-      getRecordsWithDate(vm.published_at)
+      getRecordsWithDate(vm.published_on)
 
   # 削除アイコン モーダル
   vm.destroyRecord = (index) ->
@@ -207,7 +207,7 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $uibModal, 
       resolve: { record_id: record.id }
     )
     modalInstance.result.then () ->
-      getRecordsWithDate(vm.published_at)
+      getRecordsWithDate(vm.published_on)
 
   # ラベル名 モーダル
   vm.setColor = ($tag) ->

--- a/src/app/user/mypage/mypage.jade
+++ b/src/app/user/mypage/mypage.jade
@@ -18,7 +18,7 @@
           span(translate='MESSAGES.THERE_IS_NO_RECORD2')
         table.table.table-condensed(ng-show='mypage.records.length >= 1')
           tr(ng-repeat='record in mypage.records | limitTo:5')
-            td {{ record.published_at }}
+            td {{ record.published_on }}
             td
               label.label.label-warning {{ record.category_name }}
             td


### PR DESCRIPTION
## 事象

「入力する」画面でデータを登録できず、ログを確認すると `published_on`のバリデーションエラーが発生していた。

## 対応内容

`published_at`から`published_on`にカラム名を変更した際に、フロント側の`published_at`を`published_on`に変更していなかったことが原因であるため、フロント側を一律`published_on`に変更しました。
