### PR TITLE
完了タスクが1日ずれている件について修正

### DIFF
--- a/app/controllers/api/admin/tasks/done_tasks_controller.rb
+++ b/app/controllers/api/admin/tasks/done_tasks_controller.rb
@@ -5,6 +5,6 @@ class Api::Admin::Tasks::DoneTasksController < ApplicationController
   before_action :admin_authenticate
 
   def index
-    @tasks = DoneTask.recreate!(Time.zone.yesterday)
+    @tasks = DoneTask.recreate!(Time.zone.today)
   end
 end

--- a/spec/requests/api/admin/tasks/done_tasks_spec.rb
+++ b/spec/requests/api/admin/tasks/done_tasks_spec.rb
@@ -21,17 +21,17 @@ describe 'POST /api/admin/tasks/done_tasks', autodoc: true do
 
   context '管理ユーザーがログインしている場合' do
     let!(:user) { create(:email_user, :admin_user, :registered) }
+    let!(:today) { Time.zone.today }
     let!(:yesterday) { Time.zone.yesterday }
-    let!(:two_days_ago) { 2.days.ago }
 
     shared_examples_for 'whether the task is not there' do
       context '昨日完了したタスクが3件あった場合' do
         before do
-          create(:all_done_task, confirmed_on: yesterday,
+          create(:all_done_task, confirmed_on: today,
                                  board_name: 'ボード名１', card_name: 'カード１')
-          create(:all_done_task, confirmed_on: yesterday,
+          create(:all_done_task, confirmed_on: today,
                                  board_name: 'ボード名１', card_name: 'カード２')
-          create(:all_done_task, confirmed_on: yesterday,
+          create(:all_done_task, confirmed_on: today,
                                  board_name: 'ボード名２', card_name: 'カード３')
         end
 
@@ -69,8 +69,8 @@ describe 'POST /api/admin/tasks/done_tasks', autodoc: true do
                                board_name: 'ボード名１', card_code: 'card1')
         attributes_for(:all_done_task, board_name: 'ボード名１', card_code: 'card2')
 
-        AllDoneTask.create(card1.merge(confirmed_on: two_days_ago))
         AllDoneTask.create(card1.merge(confirmed_on: yesterday))
+        AllDoneTask.create(card1.merge(confirmed_on: today))
       end
 
       it_behaves_like 'whether the task is not there'


### PR DESCRIPTION
## 事象

昨日の達成タスクを確認したいのに、
一昨日の達成タスクが通知される。

## 対応内容

前提として、朝7時に実行するタスク（API）であるため、前日の朝7時時点と一昨日の朝7時時点の差分を取得しても一昨日の達成タスクが取得されることになる。
今朝までの差分を取得し、昨日の達成タスクが通知されるように、`Time.zone.yesterday`から`Time.zone.today`に変更しました