### PR TITLE
rspec実行時のDEPRECATED WARNINGSを削除する

### DIFF
--- a/app/models/email_user.rb
+++ b/app/models/email_user.rb
@@ -8,7 +8,7 @@ class EmailUser < User
   validates :password,
             length: { minimum: Settings.user.password.minimum_length },
             on: :create
-  validate :uniqueness_email, if: 'email.present?'
+  validate :uniqueness_email, if: ->(obj) { obj.email.present? }
 
   def registration_url(origin)
     token = registration_token.token

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -20,12 +20,4 @@ class Feedback < ActiveRecord::Base
       channel: '#feedbacks'
     )
   end
-
-  private
-
-  # NOTE: parameterにメールアドレスがあるかどうかで判定している
-  # TODO: validationの条件を適正なものに修正する
-  def no_email?
-    email.nil?
-  end
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -11,7 +11,7 @@ class Feedback < ActiveRecord::Base
             presence: true,
             email_format: { allow_blank: true },
             length: { maximum: Settings.feedback.email.maximum_length },
-            unless: 'email.nil?'
+            unless: ->(obj) { obj.email.nil? }
 
   def notice_to_slack
     Slack.chat_postMessage(
@@ -19,5 +19,13 @@ class Feedback < ActiveRecord::Base
       username: "#{user.try(:id)}. #{user.try(:screen_name)}#{email}",
       channel: '#feedbacks'
     )
+  end
+
+  private
+
+  # NOTE: parameterにメールアドレスがあるかどうかで判定している
+  # TODO: validationの条件を適正なものに修正する
+  def no_email?
+    email.nil?
   end
 end


### PR DESCRIPTION
## 事象

```
DEPRECATION WARNING: Passing string to be evaluated in :if and :unless conditional options is deprecated and will be removed in Rails 5.2 without replacement. Pass a symbol for an instance method, or a lambda, proc or block, instead. (called from <class:EmailUser> at /private/var/www/new-account-book/app/models/email_user.rb:11)
DEPRECATION WARNING: Passing string to be evaluated in :if and :unless conditional options is deprecated and will be removed in Rails 5.2 without replacement. Pass a symbol for an instance method, or a lambda, proc or block, instead. (called from <class:Feedback> at /private/var/www/new-account-book/app/models/feedback.rb:10)
DEPRECATION WARNING: Passing string to be evaluated in :if and :unless conditional options is deprecated and will be removed in Rails 5.2 without replacement. Pass a symbol for an instance method, or a lambda, proc or block, instead. (called from <class:Feedback> at /private/var/www/new-account-book/app/models/feedback.rb:10)
DEPRECATION WARNING: Passing string to be evaluated in :if and :unless conditional options is deprecated and will be removed in Rails 5.2 without replacement. Pass a symbol for an instance method, or a lambda, proc or block, instead. (called from <class:Feedback> at /private/var/www/new-account-book/app/models/feedback.rb:10)
```